### PR TITLE
Enable social cards and add Netlify build cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 .pyre/
 
 **/.DS_Store
+
+# Netlify plugins
+node_modules

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,10 +49,10 @@ plugins:
   - search
   - tags
   - git-revision-date
-  # - social:
-  #     cards_color:
-  #       fill: '#0FF1CE'
-  #       text: '#FFFFFF'
+  - social:
+      cards_color:
+        fill: rgb(40, 47, 56)
+        text: white
 
 extra:
   homepage: https://hummingbot.org

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,8 @@
 [build]
     command = "pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git mkdocs-git-revision-date-plugin p && mkdocs build"
     publish = "site"
+
+[[plugins]]
+package = "netlify-plugin-cache"
+  [plugins.inputs]
+  paths = [".cache"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "netlify-plugin-cache": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/netlify-plugin-cache/-/netlify-plugin-cache-1.0.3.tgz",
+      "integrity": "sha512-CTOwNWrTOP59T6y6unxQNnp1WX702v2R/faR5peSH94ebrYfyY4zT5IsRcIiHKq57jXeyCrhy0GLuTN8ktzuQg==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "hummingbot-site",
+  "version": "1.0.0",
+  "description": "Welcome to the official website and documentation for Hummingbot and the Hummingbot Foundation!",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hummingbot/hummingbot-site.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/hummingbot/hummingbot-site/issues"
+  },
+  "homepage": "https://github.com/hummingbot/hummingbot-site#readme",
+  "devDependencies": {
+    "netlify-plugin-cache": "^1.0.3"
+  }
+}


### PR DESCRIPTION
This PR enables [social cards](https://squidfunk.github.io/mkdocs-material/setup/setting-up-social-cards/). Additionally, I've added a plugin which caches the generated social cards when building via Netlify, as image processing takes some time. I haven't used Netlify's build caching before, so let's see how that works out.

__Example__:

![7aab82a6c129e1af1dec3d53cc37c36c](https://user-images.githubusercontent.com/932156/150382952-0b749d55-0ec3-4ed9-b80f-392f5296d676.png)

__Build time__:

- 1st run: 40s
- 2nd+ run (with cache): 22s