### PR TITLE
Improve color balance

### DIFF
--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -1,3 +1,20 @@
-.md-header, .md-tabs {
-  background-color: rgb(40, 47, 56) !important;
+[data-md-color-scheme="slate"] {
+  --md-default-bg-color: rgb(29, 34, 40);
+  --md-default-bg-color--light: rgb(29, 34, 40, 0.54);
+  --md-default-bg-color--lighter: rgb(29, 34, 40, 0.26);
+  --md-default-bg-color--lightest: rgb(29, 34, 40, 0.07);
+  --md-footer-bg-color: rgb(23, 27, 32, 0.87);
+  --md-footer-bg-color-dark: rgb(23, 27, 32);
+}
+
+.md-header,
+.md-tabs,
+.md-nav--primary .md-nav__title[for="__drawer"] {
+  background-color: rgb(40, 47, 56);
+}
+
+@media screen and (max-width: 59.9375em) {
+  .md-nav__source {
+    background-color: rgb(23, 27, 32);
+  }
 }


### PR DESCRIPTION
This PR improves the overall color balance for the site, making it more pleasant to read, especially in dark mode, as the slate theme's default tone is to warm for Hummingbot's CI grey which is used in the header.

__Before__:

![screenshot-hummingbot-org-1642698594176](https://user-images.githubusercontent.com/932156/150387717-89202eaa-9d9a-4681-bc38-1642358f171e.png)

__After__:

![screenshot-localhost-8000-1642698683221](https://user-images.githubusercontent.com/932156/150387957-e0aced41-1b25-4d5a-a515-ab99a5527bae.png)

<details>
  <summary><b>Additionally, prior to this PR, the drawer on mobile did not match the header color</b></summary>

__Before__ :

<img width="368" alt="Bildschirmfoto 2022-01-20 um 17 59 17" src="https://user-images.githubusercontent.com/932156/150387992-82155aa2-23d2-4321-a84c-c91843ac7e9e.png">

__After__

<img width="366" alt="Bildschirmfoto 2022-01-20 um 18 03 58" src="https://user-images.githubusercontent.com/932156/150388038-75cd2361-68f4-421c-8d9a-0b30d13a755d.png">

</details>