### PR TITLE
Fixed invalid configuration in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://squidfunk.github.io/mkdocs-material/schema.json
+
 # Project info
 site_name: Hummingbot Foundation
 site_description: The official website and documentation site for the Hummingbot Foundation
@@ -39,10 +41,10 @@ theme:
       code: Roboto Mono
   features:
     - navigation.instant
-    - navigation.tracking # insiders
+    - navigation.tracking
     - navigation.tabs
-    - navigation.tabs.sticky # insiders
-    - navigation.indexes # insiders
+    - navigation.tabs.sticky
+    - navigation.indexes
     - navigation.top
 
 plugins:
@@ -101,12 +103,16 @@ markdown_extensions:
   - pymdownx.highlight
   - pymdownx.inlinehilite
   - pymdownx.keys
-  - pymdownx.magiclink
+  - pymdownx.magiclink:
+      user: hummingbot
+      repo: hummingbot
+      repo_url_shorthand: true
   - pymdownx.mark
   - pymdownx.smartsymbols
   - pymdownx.snippets
   - pymdownx.superfences
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.tilde


### PR DESCRIPTION
The search does not work on some sites with content tabs, because since version 8 of Material for MkDocs, content tabs demand a [new configuration syntax](https://squidfunk.github.io/mkdocs-material/upgrade/#pymdownxtabbed). Because of the old syntax, missing elements break the site, resulting in a breaking search. Try using the search on this [page](https://hummingbot.org/installation/docker/), it won't work.

This PR does several things:

1. It fixes the content tabs configuration
2. It fixes the magic link configuration, allowing to directly reference issue numbers
3. It adds a schema to the mkdocs.yml file, which was [just released](https://twitter.com/squidfunk/status/1487746003692400642). [Read more](https://squidfunk.github.io/mkdocs-material/creating-your-site/#minimal-configuration)
4. It removes the `# insiders` notes on some feature flags – all of those features are now in the community edition

Regarding magic link: I've seen you're always explicitly linking to pull request or issues in the changelog. With magiclink now properly configured, you just have to reference an issue with a hash and number, and MkDocs will auto-link it. Should we clean up the changelog in particular and documentation in general to reflect that? Example:

``` md
* Added a [fix (#1104)](https://github.com/hummingbot/hummingbot/pull/1100) in Coinbase Pro market connector to address a [bug (#1100)](https://github.com/hummingbot/hummingbot/issues/1100) that was preventing order cancellation.
```

... would become:

``` md
* Added a fix #1104 in Coinbase Pro market connector to address a bug #1100 that was preventing order cancellation.
```

Note that the "fix" or "bug" would not be included in the link title but occur before it.