### PR TITLE
Moved abbreviations into includes

### DIFF
--- a/docs/governance/proposals/index.md
+++ b/docs/governance/proposals/index.md
@@ -13,10 +13,3 @@ Each proposal type has different Governance Parameters:
 | Min HBOT Balance             | 1                         | 10,000                  | 50,000                   |
 | Quorum Percentage            | 0.1% of HBOT total supply | 3% of HBOT total supply | 10% of HBOT total supply |
 | Approval Threshold           | >50% of tokens approved   | >50% of tokens approved | >50% of tokens approved  |
-
-*[Snapshot]: Where to vote
-*[Vote Duration]: How long each vote lasts
-*[Min HBOT Balance]: Minimum HBOT balance needed to create proposal
-*[Quorum Percentage]: Total tokens that need to participate in voting for proposal to be approved
-*[Approval Threshold]: Threshold needed to approve a proposal
-

--- a/includes/abbreviations.md
+++ b/includes/abbreviations.md
@@ -1,0 +1,5 @@
+*[Snapshot]: Where to vote
+*[Vote Duration]: How long each vote lasts
+*[Min HBOT Balance]: Minimum HBOT balance needed to create proposal
+*[Quorum Percentage]: Total tokens that need to participate in voting for proposal to be approved
+*[Approval Threshold]: Threshold needed to approve a proposal

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,7 +104,10 @@ markdown_extensions:
   - pymdownx.magiclink
   - pymdownx.mark
   - pymdownx.smartsymbols
-  - pymdownx.snippets
+  - pymdownx.snippets:
+      check_paths: true
+      auto_append:
+        - includes/abbreviations.md
   - pymdownx.superfences
   - pymdownx.tabbed
   - pymdownx.tasklist:


### PR DESCRIPTION
This PR moves all abbreviations into a separate file, which is auto-appended to each Markdown file during the build. This means that all Markdown sources will be searched for those abbreviations. Closes #24.

<img width="854" alt="Bildschirmfoto 2022-01-30 um 16 32 00" src="https://user-images.githubusercontent.com/932156/151706238-56586e8c-8f6a-4f45-9d0b-2e58a60512cb.png">
