### PR TITLE
Replace emojis with icons

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ Hummingbot Foundation is a not-for-profit foundation that facilitates decentrali
 
 Help us **democratize high-frequency trading** and give sophisticated algorithms to everyone in the world!
 
-## 👨‍👩‍👧‍👧 About us
+## :material-information: About us
 
 - [About](/about): About Hummingbot and the Foundation
 - [FAQ](/faq): Answers to common questions
@@ -21,26 +21,26 @@ Help us **democratize high-frequency trading** and give sophisticated algorithms
 - [HBOT](/hbot): How to claim, vote, and earn Hummingbot Governance Tokens (HBOT)
 - [Community](/community): Participate in the global Hummingbot ecosystem
 
-## 📚 Read the docs
+## :material-library: Read the docs
 
 - [Documentation](/docs): Learn how to use Hummingbot
 - [Developers](/developers): Start building your own connectors and strategies
 - [Releases](/release-notes): What's included in the latest release
 
-## ✅ Govern with HBOT
+## :material-robot-happy: Govern with HBOT
 
 - [Governance](/governance): All things related to Foundation governance
 - [Whitepaper](/governance/whitepaper): Detailed description of how the governance system works
 - [Proposals](/governance/proposals): Different types of proposals
 - [Epochs](/governance/epochs): Fixed HBOT distribution cycles
 
-## 💪 Contribute to Hummingbot
+## :octicons-git-pull-request-16: Contribute to Hummingbot
 
 - [Contribution Guidelines](/developers/contributions/): Read this before submitting a pull request
 - [Maintenance](/maintenance): Get paid for building and maintaining Hummingbot components
 
-## 📬 Newsletter
+## :fontawesome-solid-paper-plane: Newsletter
 
 Sign up for the [official Hummingbot newsletter](https://hummingbot.substack.com/), which is published when each monthly release drops. The newsletter also contains Foundation news, upcoming events, and updates about contributions from the global Hummingbot community!
 
-[Get the Hummingbot newsletter :fontawesome-solid-paper-plane:](https://hummingbot.substack.com/){ .md-button .md-button--primary }
+[Get the Hummingbot newsletter](https://hummingbot.substack.com/){ .md-button .md-button--primary }


### PR DESCRIPTION
This PR is meant as a basis for discussions about replacing the use of emojis with icons. While emojis allow to easier scan content and find information quicker, my experience is that they sometimes look a little juvenile and make the project look less professional. However, for a long time they were the only possibility to add pictograms to MkDocs.

Since Material for MkDocs 5, we have the [icon integration](https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/#using-icons) which allows us to use 9k icons directly from Markdown. I'm making heavy use of them in Material for MkDocs's own documentation. Since Hummingbot is using [Insiders](https://squidfunk.github.io/mkdocs-material/insiders/), we could even attach [icons to pages](https://squidfunk.github.io/mkdocs-material/reference/#setting-the-page-icon) (as can be seen on the left).

So the question is: should we invest time into finding a good subset of icons to be used throughout the documentation as a replacement for emojis? I could provide a first selection, which we could then discuss.