### PR TITLE
(doc) Update installation links for Docker

### DIFF
--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -1,6 +1,6 @@
 # Install Hummingbot with Docker
 
-CoinAlpha publishes [Docker images](https://hub.docker.com/r/coinalpha/hummingbot) for the `latest` and `development` builds of Hummingbot, as well as every version. 
+The [Hummingbot DockerHub](https://hub.docker.com/r/hummingbot/hummingbot) publishes Docker images for the `master` (latest) and `development` builds of Hummingbot starting with version 1.5.0. For previous versions you may download the docker images from [CoinAlpha's Dockerhub](https://hub.docker.com/r/coinalpha/hummingbot)  
 
 You can install Docker and Hummingbot by selecting the following options below:
 
@@ -89,7 +89,7 @@ _Supported versions: 16.04 LTS, 18.04 LTS, 19.04_
     --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_logs,destination=/logs/" \
     --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_data,destination=/data/" \
     --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_scripts,destination=/scripts/" \
-    coinalpha/hummingbot:latest
+    hummingbot/hummingbot:latest
     ```
 
 ## MacOS
@@ -131,7 +131,7 @@ You can install Docker by [downloading an installer](https://docs.docker.com/doc
     --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_logs,destination=/logs/" \
     --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_data,destination=/data/" \
     --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_scripts,destination=/scripts/" \
-    coinalpha/hummingbot:latest
+    hummingbot/hummingbot:latest
     ```
 
 ## Windows
@@ -168,10 +168,87 @@ Alternatively, after WSL is installed, search for **Ubuntu** in the Windows Stor
 
 ![Powershell start](/assets/img/wsl-distros.png)
 
-**5. Install Docker and Hummingbot**
+### Install Docker in WSL
+
+**5. Install Docker**
 
 With WSL installed, you now have a Linux Virtual Machine running under Windows.
 
 ![Linux on Windows](/assets/img/wsl-running.png)
 
-Follow the instructions in the **Install Hummingbot** section above to complete the installation process.
+Follow the instructions below to complete the Docker installation process.
+
+```bash 
+# 1) Remove older / currently installed versions of Docker first 
+sudo apt-get remove docker docker-engine docker.io containerd runc
+
+# 2) Update the package index
+sudo apt-get update && sudo apt-get upgrade -y
+
+# 3) Install necessary packages
+sudo apt-get install apt-transport-https ca-certificates curl software-properties-common gnupg lsb-release
+
+# 4) Add Docker's official GPG key 
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+
+# 5) Setup the repository
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs)  stable"
+
+# 6) Install Docker
+sudo apt update && sudo apt-get install docker-ce
+
+# 7) Start the Docker service
+sudo service docker start 
+
+# 8) Allow docker commands without requiring sudo prefix. If you are running as root replace $USER with your username
+sudo usermod -aG docker $USER
+
+# 9) Restart the terminal first before running the create.sh script (Important!)
+exit
+``` 
+
+!!! warning
+    Please restart terminal — close and restart your terminal window to enable the correct permissions for `docker` command before proceeding to next step.
+
+### Install Hummingbot 
+
+**6. Download the scripts or use the manual method**
+
+=== "Scripts"
+
+    ```bash
+    # 1) Download Hummingbot install, start, and update script
+    wget https://raw.githubusercontent.com/hummingbot/hummingbot/master/installation/docker-commands/create.sh
+    wget https://raw.githubusercontent.com/hummingbot/hummingbot/master/installation/docker-commands/start.sh
+    wget https://raw.githubusercontent.com/hummingbot/hummingbot/master/installation/docker-commands/update.sh
+
+    # 2) Enable script permissions
+    chmod a+x *.sh
+
+    # 3) Create a hummingbot instance
+    ./create.sh
+    ```
+
+=== "Manual"
+
+    ```bash
+    # 1) Create folder for your new instance
+    mkdir hummingbot_files
+
+    # 2) Create folders for logs, config files and database file
+    mkdir hummingbot_files/hummingbot_conf
+    mkdir hummingbot_files/hummingbot_logs
+    mkdir hummingbot_files/hummingbot_data
+    mkdir hummingbot_files/hummingbot_scripts
+
+    # 3) Launch a new instance of hummingbot
+    docker run -it \
+    --network host \
+    --name hummingbot-instance \
+    --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_conf,destination=/conf/" \
+    --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_logs,destination=/logs/" \
+    --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_data,destination=/data/" \
+    --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_scripts,destination=/scripts/" \
+    hummingbot/hummingbot:latest
+    ```
+

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -25,7 +25,7 @@ Download and run the binary installer to install the last available binary relea
 
 ### 🐳 Docker
 
-The [Hummingbot DockerHub](https://hub.docker.com/r/coinalpha/hummingbot) publishes Docker images for the `master` (latest) and `development` builds of Hummingbot, as well as past versions. 
+The [Hummingbot DockerHub](https://hub.docker.com/r/hummingbot/hummingbot) publishes Docker images for the `master` (latest) and `development` builds of Hummingbot starting with version 1.5.0. For previous versions you may download the docker images from [CoinAlpha's Dockerhub](https://hub.docker.com/r/coinalpha/hummingbot) 
 
 We recommend this path for users who run Hummingbot on Linux, in the cloud, and/or multiple bots.
 
@@ -51,7 +51,7 @@ Hummingbot has been successfully tested with the following specifications:
 
 | Resource             | Requirement                                                                                                                  |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| **Operating System** | **Linux**: Ubuntu 16.04 or later (recommended) \*Other Linux installations: Debian GNU/Linux 9, CentOS 7, Amazon Linux 2 AMI |
+| **Operating System** | **Linux**: Ubuntu 18.04 or later (recommended) \*Other Linux installations: Debian GNU/Linux 9, CentOS 7, Amazon Linux 2 AMI |
 |                      | **MacOS**: macOS 10.12.6 (Sierra) or later                                                                                   |
 |                      | **Windows**: Windows 10 or later                                                                                             |
 | **Memory/RAM**       | 1 GB one instance _+250 MB per additional instance_                                                                          |

--- a/docs/installation/raspberry-pi.md
+++ b/docs/installation/raspberry-pi.md
@@ -30,7 +30,7 @@ Exit
 
 **Install Hummingbot**
 
-The Latest ARM version can be found here (filter list by "arm") - [CoinAlpha DockerHub](https://hub.docker.com/r/coinalpha/hummingbot/tags?page=1&ordering=last_updated&name=arm)
+The Latest ARM version can be found here (filter list by "arm") - [Hummingbot DockerHub](https://hub.docker.com/r/hummingbot/hummingbot/tags?page=1&ordering=last_updated&name=arm)
 
 You can install Hummingbot with **_either_** of the following options:
 
@@ -53,7 +53,7 @@ You can install Hummingbot with **_either_** of the following options:
 
     # 4) Pull Hummingbot ARM image when asked what version to use
     Enter Hummingbot version: [ latest/development ] ( default = 'latest' )
-    >> version-1.1.0-arm_beta
+    >> version-1.5.0-arm_beta
     ```
 
 === "Manual"
@@ -76,7 +76,7 @@ You can install Hummingbot with **_either_** of the following options:
     --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_logs,destination=/logs/" \
     --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_data,destination=/data/" \
     --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_scripts,destination=/scripts/" \
-    coinalpha/hummingbot:version-1.1.0-arm_beta
+    hummingbot/hummingbot:version-1.5.0-arm_beta
     ```
 
 ## Install from source

--- a/docs/installation/update-hummingbot.md
+++ b/docs/installation/update-hummingbot.md
@@ -19,7 +19,7 @@ For example:
 
 Hummingbot is regularly updated each month (see [Release Notes](/release-notes/)) and recommends users to periodically update their installations to get the latest version of the software.
 
-Updating to the latest docker image (e.g. `coinalpha/hummingbot:latest`)
+Updating to the latest docker image (e.g. `hummingbot/hummingbot:latest`)
 
 !!! note
     Make sure to stop all the containers using the same image first  before running the `./update.sh` script.
@@ -47,7 +47,7 @@ Updating to the latest docker image (e.g. `coinalpha/hummingbot:latest`)
     docker rm hummingbot-instance
 
     # 2) Delete old hummingbot image
-    docker image rm coinalpha/hummingbot:latest
+    docker image rm hummingbot/hummingbot:latest
 
     # 3) Re-create instance with latest hummingbot release
     docker run -it \
@@ -56,9 +56,9 @@ Updating to the latest docker image (e.g. `coinalpha/hummingbot:latest`)
     --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_conf,destination=/conf/" \
     --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_logs,destination=/logs/" \
     --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_data,destination=/data/" \
-    coinalpha/hummingbot:latest
+    hummingbot/hummingbot:latest
     ```
-A previous version (i.e. `version-0.30.0`) can be installed when creating a Hummingbot instance.
+A previous version (i.e. `version-1.4.0`) can be installed when creating a Hummingbot instance.
 
 ## Raspberry Pi
 
@@ -74,10 +74,10 @@ Instead, you need to run `./create.sh` to create a new instance with the latest 
 
     # 2) Pull Hummingbot ARM image when asked what version to use
     Enter Hummingbot version [ latest/development ] ( default = 'latest' )
-    >> version-0.44.0-arm_beta 
+    >> version-1.4.0-arm_beta 
     ```
 !!! Note
-    The latest ARM version of Hummingbot can be found here (filter list by "arm") - https://hub.docker.com/r/coinalpha/hummingbot/tags?page=1&ordering=last_updated&name=arm
+    The latest ARM version of Hummingbot can be found here (filter list by "arm") - [Hummingbot Dockerhub](https://hub.docker.com/r/hummingbot/hummingbot/tags?page=1&ordering=last_updated&name=arm)
 
 
 ## Source


### PR DESCRIPTION
- updated DockerHub links from CoinAlpha to Foundation DH 
- added install instructions for Docker on WSL
![2022-07-12_005555](https://user-images.githubusercontent.com/85695272/178325455-04fb527e-7d9e-4128-9b2b-ee5f707d85fa.jpg)
![2022-07-12_010131](https://user-images.githubusercontent.com/85695272/178325521-746f2285-543b-4e9f-bb83-454a9c33d47d.jpg)
![2022-07-12_011301](https://user-images.githubusercontent.com/85695272/178325548-ed432cda-1901-489e-b383-be60adac8cf7.jpg)


