### PR TITLE
fix spelling in start arg script

### DIFF
--- a/docs/developers/scripts/getting-started.md
+++ b/docs/developers/scripts/getting-started.md
@@ -11,7 +11,7 @@ All script examples are located in the [`/scripts`](https://github.com/hummingbo
 
 ## Running a script
 
-From the Hummingbot client interface, enter `start --scripts [filename]` to start a script. 
+From the Hummingbot client interface, enter `start --script [filename]` to start a script. 
 
 Run `stop` to stop a script.
 


### PR DESCRIPTION
--scripts arg for start command doesn't exist -> use --script instead.