### PR TITLE
(doc) update broken links

### DIFF
--- a/docs/news/foundation.md
+++ b/docs/news/foundation.md
@@ -57,7 +57,7 @@ Hummingbot’s main value proposition is enabling users to run high-frequency tr
 
 While Hummingbot is a general toolbox that can be used to build any type of trading bot, we focus on market making and arbitrage bots because usage of those strategies benefits our exchange and protocol partners.
 
-Supported by [0x](https://0x.org/), who gave us a developer grant, we [launched Hummingbot](https://hummingbot.io/en/blog/2019-04-announcing-hummingbot/) in April 2019 with connectors to two exchanges: Binance.com and Radar Relay, an early decentralized exchange.
+Supported by [0x](https://0x.org/), who gave us a developer grant, we [launched Hummingbot](https://hummingbot.io/blog/2019-04-announcing-hummingbot/) in April 2019 with connectors to two exchanges: Binance.com and Radar Relay, an early decentralized exchange.
 
 Today, [Hummingbot](https://github.com/hummingbot/hummingbot) has become the leading open source crypto trading bot with:
 

--- a/docs/news/hbot.md
+++ b/docs/news/hbot.md
@@ -9,7 +9,7 @@ hide:
 
 *Posted on December 17, 2021*
 
-As announced in [this October post](https://hummingbot.io/en/blog/hummingbot-foundation/), CoinAlpha has established the Hummingbot Foundation (the "Foundation"), a new, independent open source foundation that will enable a decentralized, community-led software development model for Hummingbot, an open source toolbox for building crypto trading bots.
+As announced in [this October post](https://hummingbot.io/blog/hummingbot-foundation/), CoinAlpha has established the Hummingbot Foundation (the "Foundation"), a new, independent open source foundation that will enable a decentralized, community-led software development model for Hummingbot, an open source toolbox for building crypto trading bots.
 
 Like our spiritual predecessor the Linux Foundation, we believe that community maintenance is key to scaling Hummingbot to every exchange and blockchain and enabling traders to build any type of bot.
 

--- a/docs/release-notes/0.46.0.md
+++ b/docs/release-notes/0.46.0.md
@@ -7,10 +7,9 @@
 
 We are very excited to ship the December 2021 Hummingbot release (v0.46.0) today! This release contains significant improvements to the `avellaneda` and `perpetual_market_making` strategies, new connectors to MEXC and WazirX, and a brand-new approach to paper trading!
 
-v0.46 will be the last beta release of Hummingbot. Going forward, the [Hummingbot Foundation](https://hummingbot.io/en/blog/hummingbot-foundation/) will begin to enact a process that enables the community to participate in deciding what’s included in each Hummingbot release.
+v0.46 will be the last beta release of Hummingbot. Going forward, the [Hummingbot Foundation](https://hummingbot.io/blog/hummingbot-foundation/) will begin to enact a process that enables the community to participate in deciding what’s included in each Hummingbot release.
 
 To mark this shift to a new community-oriented direction for Hummingbot, the next release will be **Hummingbot 1.0** and is planned for mid-January 2022.
-
 
 ## Discontinue Binary Support
 
@@ -18,8 +17,7 @@ In this release, we added a package dependency required for improving Avellaneda
 
 Currently, `loopring` and `dydx_perpetual` connectors as well as `amm_arbitrage` strategy, do not work with binary versions and we have encountered other similar issues in previous releases caused by these incompatibilities. After this release, we will deprecate and no longer support binary versions.
 
-New users who want to test and try out Hummingbot can launch an instance of our Test Drive from https://hummingbot.io/en/test-drive/.
-
+New users who want to test and try out Hummingbot can launch an instance of our Test Drive from <https://hummingbot.io/test-drive/>.
 
 ## Reworked Paper Trade Mode
 
@@ -29,7 +27,6 @@ As our codebase grows, the current design will not be able to support all strate
 
 To enable paper trading, users will now have to select paper trade exchanges when configuring a strategy. Read more about [Paper Trade](/global-configs/paper-trade) in our documentation.
 
-
 ## Improved Avellaneda Market Making (Part 1)
 
 We are making improvements to the initial implementation of the Avellenada-Stoikov strategy. In this release, we fixed the greek parameters `gamma` (risk factor), `eta` (shape factor), and `kappa` (liquidity factor) to use the calculation of its original design.
@@ -37,7 +34,6 @@ We are making improvements to the initial implementation of the Avellenada-Stoik
 Some advanced parameters were added and we removed those that were not a requirement for the strategy to behave correctly. The updated list of parameters can be found in [Avellaneda Market Making](/strategies/avellaneda-market-making/#strategy-configs) documentation.
 
 In the next release, we will rework the time factor to allow an infinite time horizon as described in Github issue [#4650](https://github.com/hummingbot/hummingbot/issues/4650).
-
 
 ## Simplified Perpetual Market Making
 
@@ -52,20 +48,17 @@ Some other changes and improvements are:
 
 More detailed information on these changes can be found in Github issue [#4565](https://github.com/hummingbot/hummingbot/issues/4565) and updated [Perpetual Market Making](/strategies/perpetual-market-making) documentation.
 
-
 ## New Spot Connector: MEXC Global
 
 Launched in April 2018, [MEXC Global](https://www.mexc.com/) is a centralized cryptocurrency exchange registered in Seychelles. The exchange supports USD, GBP, EUR, AUD and VND deposit and withdrawal.
 
 More information about the connector in [MEXC](/exchanges/mexc/) documentation.
 
-
 ## New Spot Connector: WazirX
 
 Launched in 2018, [WazirX](https://wazirx.com/) aims to make crypto accessible to everyone in India, with over 400,000 users and an average app rating of 4.6. WazirX is a part of the Binance ecosystem and was acquired by Binance in November 2019.
 
 More information about the connector in [WazirX](/exchanges/wazirx/) documentation.
-
 
 ## Client UI Improvements
 
@@ -74,7 +67,6 @@ More information about the connector in [WazirX](/exchanges/wazirx/) documentati
 - Inspired by [zappra](https://github.com/zappra)'s pull request submission [#3154](https://github.com/hummingbot/hummingbot/pull/3154), running `order_book --live` command will show a live output of the order book in a tab in the logs pane
 
 We will continue to work on adding more features that can be displayed in the tabs. Please feel free to [submit a feature request](https://github.com/hummingbot/hummingbot/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=) for any suggestions.
-
 
 ## Developer Updates
 
@@ -87,7 +79,6 @@ We will continue to work on adding more features that can be displayed in the ta
 - Removed `NetworkStatus` class in `network_base`, keeping the definition of the class only in `network_iterator` core component. **Thanks to [blakephillips](https://github.com/blakephillips) for this contribution! 🙏**
 - Packages are automatically detected instead of manually listing out the sub-packages in [`setup.py`](https://github.com/hummingbot/hummingbot/blob/master/setup.py#L37)
 - `GateIoAPIOrderBookDataSource` now uses a single websocket connection to open as little websocket connection as possible. More information in [#4562](https://github.com/hummingbot/hummingbot/pull/4562)
-
 
 ## Bug Fixes
 

--- a/docs/release-notes/1.0.0.md
+++ b/docs/release-notes/1.0.0.md
@@ -4,9 +4,9 @@
 
 - **Install via Docker**: [Linux](/installation/docker/#linuxubuntu) | [Windows](/installation/docker/#windows) | [macOS](/installation/docker/#macos) | [Raspberry Pi](/installation/raspberry-pi/#install-via-docker)
 
-We are very excited to ship the first official Hummingbot release (v1.0.0) today! 
+We are very excited to ship the first official Hummingbot release (v1.0.0) today!
 
-This release contains significant improvements to the `avellaneda` strategies, major updates of Binance and Binance Perpetual connectors, discontinue of the Binary build, and improved documentation for both Avellaneda and Perpetual market making strategies as well as developer documentation for perpetual connectors. 
+This release contains significant improvements to the `avellaneda` strategies, major updates of Binance and Binance Perpetual connectors, discontinue of the Binary build, and improved documentation for both Avellaneda and Perpetual market making strategies as well as developer documentation for perpetual connectors.
 
 ## Binance and Binance Perpetual Improvement
 
@@ -31,13 +31,13 @@ Changes can be seen here for [Binance](https://github.com/hummingbot/hummingbot/
 
 We previously announced in the version 0.46 release notes about discontinuing binary installers. In this release, we have removed and cleaned up the codebase anything related to supporting binary installation, however, users can continue to use the older version of binaries available until version 0.46. that can be downloaded from the installation page.
 
-New users who want to test and try out Hummingbot can launch an instance of Test Drive at https://hummingbot.io/en/test-drive/.
+New users who want to test and try out Hummingbot can launch an instance of Test Drive at <https://hummingbot.io/test-drive/>.
 
 ## Improved Avellaneda Market Making (Part 2)
 
-We are making improvements to the initial implementation of the Avellaneda-Stoikov strategy. In this release, we added improvements specifically to the infinite time horizon, making more sense for crypto markets since they run 24/7. The original strategy was invented for stock markets which are only active during certain trading hours. 
+We are making improvements to the initial implementation of the Avellaneda-Stoikov strategy. In this release, we added improvements specifically to the infinite time horizon, making more sense for crypto markets since they run 24/7. The original strategy was invented for stock markets which are only active during certain trading hours.
 
-Users can now set an infinite time horizon. Additionally, users can specify the strategy to run from time to time every day, or from one date to another date, making the strategy more flexible. For example, users can schedule the strategy to run only during a mining campaign or schedule it to only run during hours when the user is awake to keep an eye on it. 
+Users can now set an infinite time horizon. Additionally, users can specify the strategy to run from time to time every day, or from one date to another date, making the strategy more flexible. For example, users can schedule the strategy to run only during a mining campaign or schedule it to only run during hours when the user is awake to keep an eye on it.
 
 Three different use cases are possible in the current implementation:
 
@@ -46,7 +46,6 @@ Three different use cases are possible in the current implementation:
 - C: The trader wants to run the bot 24 hours, but until a certain date      (fixed_end_date)
 
 More details are described in the Github issue [#4650](https://github.com/hummingbot/hummingbot/issues/4650).
-
 
 ## Developer Updates
 
@@ -65,5 +64,5 @@ More details are described in the Github issue [#4650](https://github.com/hummin
 - [#4869](https://github.com/hummingbot/hummingbot/issues/4869) Fixed Avellaneda Market Making order refresh tolerance not working
 - [#4894](https://github.com/hummingbot/hummingbot/issues/4894) Top bid is assigned top ask in Cross Exchange Market Making
 - [$4914](https://github.com/hummingbot/hummingbot/issues/4914) Fixed randomly appearing `RunTimeWarning` on the log pane
-- [#4923](https://github.com/hummingbot/hummingbot/pull/4923) Fixed trade monitor freezing 
+- [#4923](https://github.com/hummingbot/hummingbot/pull/4923) Fixed trade monitor freezing
 - [#4998](https://github.com/hummingbot/hummingbot/pull/4998) Fixed the argument -h and --help they now print help for the particular command, and these options are also being displayed in dropdown menus

--- a/docs/strategies/amm-arbitrage.md
+++ b/docs/strategies/amm-arbitrage.md
@@ -53,6 +53,6 @@ Hummingbot will be accessing `amm` exchanges via Gateway V2 from v1.4.0. If you 
 
 :fontawesome-solid-book: [How to arbitrage AMMs like Uniswap and Balancer](https://blog.hummingbot.org/blog-2020-12-amm-arbitrage-uniswap-balancer/): Learn how you can Arbitrage AMMs with our strategy
 
-:fontawesome-solid-book: [Quickstart Guide for amm_arb (deprecated)](https://hummingbot.io/en/academy/amm-arb): This guide will walk you through the installation and launch of the new `amm_arb` strategy
+:fontawesome-solid-book: [Quickstart Guide for amm_arb (deprecated)](https://hummingbot.io/academy/amm-arb): This guide will walk you through the installation and launch of the new `amm_arb` strategy
 
-*Check out [Hummingbot Academy](https://hummingbot.io/en/academy) for more resources related to this strategy and others!*
+*Check out [Hummingbot Academy](https://hummingbot.io/academy) for more resources related to this strategy and others!*

--- a/docs/strategies/arbitrage.md
+++ b/docs/strategies/arbitrage.md
@@ -64,13 +64,13 @@ Before the strategy looks at the two markets for profitable trades, it needs to 
 There are a few conditions that the strategy would check for at every tick, before proceeding to looking at the market order books:
 
  1. Are both markets connected and ready?
- 
+
     If any of the left or right markets is not ready, or is disconnected; then no arbitrage trade is possible.
- 
+
  2. Are there pending market orders on the markets that are still being processed?
 
     If there are outstanding market orders still being processed in the markets, then no further arbitrage trade is possible.
- 
+
  3. Has there been a recent arbitrage trade within the cooldown period?
 
     If an arbitrage trade has happened recently, within the cooldown period (the `next_trade_delay_interval` init argument in [arbitrage.pyx](https://github.com/hummingbot/hummingbot/blob/master/hummingbot/strategy/arbitrage/arbitrage.pyx)), then no arbitrage is possible for this tick. This wait is needed because asset balances on markets often need some delay before they are updated, after the last trade.
@@ -106,11 +106,10 @@ If the calculated arbitrage size is greater than 0, then the arbitrage strategy 
 
 The order execution logic can be found in the function `c_process_market_pair_inner()` inside [arbitrage.pyx](https://github.com/hummingbot/hummingbot/blob/master/hummingbot/strategy/arbitrage/arbitrage.pyx).
 
-
 ## ℹ️ More Resources
 
-:fontawesome-solid-book: [What is Arbitrage?](https://hummingbot.io/en/blog/2020-09-what-is-arbitrage/): The concept of arbitrage is fairly simple: Arbitrage is the purchase and sale of an asset in order to benefit from a difference in the price of the asset between markets.
+:fontawesome-solid-book: [What is Arbitrage?](https://hummingbot.io/blog/2020-09-what-is-arbitrage/): The concept of arbitrage is fairly simple: Arbitrage is the purchase and sale of an asset in order to benefit from a difference in the price of the asset between markets.
 
 :fontawesome-brands-youtube: [How to Spot Market Making and Arbitrage Opportunities?](https://www.youtube.com/watch?v=szAm_2ssXCU): Learn how to optimize the arbitrage strategy for different opportunities.
 
-*Check out [Hummingbot Academy](https://hummingbot.io/en/academy) for more resources related to this strategy and others!*
+*Check out [Hummingbot Academy](https://hummingbot.io/academy) for more resources related to this strategy and others!*

--- a/docs/strategies/aroon-oscillator.md
+++ b/docs/strategies/aroon-oscillator.md
@@ -74,9 +74,9 @@ This strategy was the winning submission in the Hummingbot track of the [Open De
 
 *By [squarelover](https://github.com/squarelover) - see original [pull request](https://github.com/hummingbot/hummingbot/pull/3430)*
 
-One of the major downsides to many of the Market-Making strategies in Hummingbot is that they don't understand trends. In my experience, I've often had my bots trade on the wrong side of a trend. This is what it frequently looks like: 
+One of the major downsides to many of the Market-Making strategies in Hummingbot is that they don't understand trends. In my experience, I've often had my bots trade on the wrong side of a trend. This is what it frequently looks like:
 ![Bad Bad Bot, No Good!](https://www.dropbox.com/temp_thumb_from_token/s/2q3j6mnnqup0bl4?preserve_transparency=False&size=1200x1200&size_mode=4)
-_Bad Bad Bot, No Good!_ ⬆️
+*Bad Bad Bot, No Good!* ⬆️
 
 My strategy attempts to take a well-known set of Market Indicators called Aroon Indicators. These indicators collect trade prices over a configurable set of periods of a given duration. The indicators represent how recent the highest highs and the lowest lows are. And the Oscillator indicator can strongly suggest a market trend. I've tried to distill what the indicators signify and use them to adjust spreads so traders are positioned at the hopefully the best point to execute at profitable positions. In other words, it tries to be better at buying low and selling high.
 
@@ -84,7 +84,7 @@ Here's a screenshot of the status screen:
 ![Aroon Indicators](https://www.dropbox.com/temp_thumb_from_token/s/2vjh58hkbscrvh6?preserve_transparency=False&size=1200x1200&size_mode=4)
 
 You can learn more about Aroon Indicators, here:
-https://www.investopedia.com/terms/a/aroon.asp
+<https://www.investopedia.com/terms/a/aroon.asp>
 
 The Aroon Oscillator strategy is a market-making strategy that uses Aroon Indicators to detect trends.
 A user will set up the number of periods in the Indicator and how long each period is in seconds.
@@ -102,7 +102,7 @@ The time duration of the period can be chosen to best suit your trade strategy. 
 `minimum_periods` can be set to have the indicator engage adjusting the spreads before the Indicator
 periods fill up. Set this to -1 to have only adjust spreads when the indicator is full.
 
-The strategy will adjust the `bid_spread` closer to `minimum_spread` the closer Aroon Down indicator gets to 100. It will adjust the `ask_spread` closer to the `minimum_spread` the closer Aroon Up gets to 100. 
+The strategy will adjust the `bid_spread` closer to `minimum_spread` the closer Aroon Down indicator gets to 100. It will adjust the `ask_spread` closer to the `minimum_spread` the closer Aroon Up gets to 100.
 
 The spread is further adjusted by the Aroon Oscillator indicator. If the indicator strongly
 suggests a trend, it will push the spread out further from `minimum_spread` in order to wait for a more optimal
@@ -119,4 +119,4 @@ well with the Indicator.
 
 :fontawesome-brands-youtube: [Aroon Indicator Strategy Hummingbot Live Followup](https://www.youtube.com/watch?v=5iOorb46aVw): Learn how to set up an `aroon-oscillator` bot.
 
-*Check out [Hummingbot Academy](https://hummingbot.io/en/academy) for more resources related to this strategy and others!*
+*Check out [Hummingbot Academy](https://hummingbot.io/academy) for more resources related to this strategy and others!*

--- a/docs/strategies/avellaneda-market-making.md
+++ b/docs/strategies/avellaneda-market-making.md
@@ -191,4 +191,4 @@ The `minimum_spread` parameter is optional, it has no effect on the calculated r
 
 :fontawesome-brands-youtube: [New Avellaneda Market Making Strategy Demo + AMA | Hummingbot Live](https://www.youtube.com/watch?v=ZbkkGvB-fis): Demo of the latest iteration of Avellaneda Market Making strategy
 
-*Check out [Hummingbot Academy](https://hummingbot.io/en/academy) for more resources related to this strategy and others!*
+*Check out [Hummingbot Academy](https://hummingbot.io/academy) for more resources related to this strategy and others!*

--- a/docs/strategies/celo-arbitrage.md
+++ b/docs/strategies/celo-arbitrage.md
@@ -46,10 +46,10 @@ It executes offsetting buy and sell orders in both markets in order to capture a
 
 ## ℹ️ More Resources
 
-:fontawesome-solid-book: [Quickstart Guide for celo-arb](https://hummingbot.io/en/academy/celo-arb/?_ga=2.247744654.866973443.1649059002-567388704.1647856298): We have created this guide to help users of the new celo-arb strategy install and run the strategy on a cloud instance.
+:fontawesome-solid-book: [Quickstart Guide for celo-arb](https://hummingbot.io/academy/celo-arb/?_ga=2.247744654.866973443.1649059002-567388704.1647856298): We have created this guide to help users of the new celo-arb strategy install and run the strategy on a cloud instance.
 
 :fontawesome-solid-book: [How celo-arb works](https://blog.hummingbot.org/blog-2020-06-celo-arbitrage/): This article guides you in running the `celo-arb` strategy.
 
 :fontawesome-solid-book: [New arbitrage opportunity: Wrapped CELO](https://blog.hummingbot.org/blog-2020-12-wrapped-celo-uniswap-arbitrage/): This article introduces a new arbitration strategy known as Wrapped Celo arbitration.
 
-*Check out [Hummingbot Academy](https://hummingbot.io/en/academy) for more resources related to this strategy and others!*
+*Check out [Hummingbot Academy](https://hummingbot.io/academy) for more resources related to this strategy and others!*

--- a/docs/strategies/cross-exchange-market-making.md
+++ b/docs/strategies/cross-exchange-market-making.md
@@ -178,4 +178,4 @@ Another difference is dependence of transaction fees on currrent gas fees. There
 
 :fontawesome-brands-youtube: [Cross Exchange Market Making Strategy in FTX | Hummingbot Live](https://www.youtube.com/watch?v=gwLjSe0t8K8): In this video, Paulo shows how to optimize a Cross Exchange Market-Making strategy in the FTX exchange connector using the Hummingbot app.
 
-*Check out [Hummingbot Academy](https://hummingbot.io/en/academy) for more resources related to this strategy and others!*
+*Check out [Hummingbot Academy](https://hummingbot.io/academy) for more resources related to this strategy and others!*

--- a/docs/strategies/fixed-grid.md
+++ b/docs/strategies/fixed-grid.md
@@ -11,7 +11,7 @@ tags:
 
 ## 📝 Summary
 
-The `fixed_grid` strategy is similar to "Grid Trading Bot" strategies available on popular exchanges such as Binance and Kucoin, which are often the entry point of users to algorithmic trading in crypto. The strategy may provide a useful tool for market making in consolidating or range-bound markets, as well as for stablecoin pairs. 
+The `fixed_grid` strategy is similar to "Grid Trading Bot" strategies available on popular exchanges such as Binance and Kucoin, which are often the entry point of users to algorithmic trading in crypto. The strategy may provide a useful tool for market making in consolidating or range-bound markets, as well as for stablecoin pairs.
 
 The main parameters needed to set up this strategy are `grid_price_ceiling`, `grid_price_floor`, `n_levels` (the number of grid levels).
 
@@ -95,4 +95,4 @@ The `order_optimization` and depth options are only for the starting rebalance o
 
 ## ℹ️ More Resources
 
-*Check out [Hummingbot Academy](https://hummingbot.io/en/academy) for more resources related to this strategy and others!*
+*Check out [Hummingbot Academy](https://hummingbot.io/academy) for more resources related to this strategy and others!*

--- a/docs/strategies/hedge.md
+++ b/docs/strategies/hedge.md
@@ -101,4 +101,4 @@ In the 3-part series below, Paulo will discuss Hedge in Market Making, including
 
 :fontawesome-brands-youtube: [Hedge in Market Making using dYdX Perpetuals | Trader Strategies | Part 03](https://www.youtube.com/watch?v=E_M_SUAP3Zo&t=8s)
 
-*Check out [Hummingbot Academy](https://hummingbot.io/en/academy) for more resources related to this strategy and others!*
+*Check out [Hummingbot Academy](https://hummingbot.io/academy) for more resources related to this strategy and others!*

--- a/docs/strategies/index.md
+++ b/docs/strategies/index.md
@@ -45,7 +45,7 @@ Market making strategies help you provide liquidity to an exchange while mitigat
 * [HBOT 101 : What Is Market Making?](https://blog.hummingbot.org/blog-2020-09-what-is-market-making/)
   * This article goes through the basic concepts of market making for beginners.
 
-* [Basic concepts of Crypto Trading](https://hummingbot.io/en/academy/basic-concepts-of-crypto-trading/#market-makers-and-market-takers)
+* [Basic concepts of Crypto Trading](https://hummingbot.io/academy/basic-concepts-of-crypto-trading/#market-makers-and-market-takers)
   * Basic 101 concepts of crypto trading and common terminologies.
 
 * [How does Market Making work?](https://hummingbot.org/news/market-making/)
@@ -92,4 +92,4 @@ Arbitrage is the buying and selling of an asset in order to benefit from a diffe
 
 :fontawesome-brands-youtube: [Create a Custom Strategy | Hummingbot Live](https://www.youtube.com/watch?v=td-E3M0qRsA&list=PLDwlNkL_4MMfdo3Vax5HUwvaduSu33-Mk): Learn about creating custom strategies with Paulo. Hummingbot lets you customize your strategies by configuring your bots to optimize its maximum potential in liquidity providing.
 
-*Check out [Hummingbot Academy](https://hummingbot.io/en/academy) for more resources related to this strategy and others!*
+*Check out [Hummingbot Academy](https://hummingbot.io/academy) for more resources related to this strategy and others!*

--- a/docs/strategies/liquidity-mining.md
+++ b/docs/strategies/liquidity-mining.md
@@ -51,10 +51,8 @@ This strategy allows market making across multiple pairs on an exchange on a sin
 
 :fontawesome-solid-globe: [Hummingbot Miner Help Center](https://support.hummingbot.io): Check out our latest announcements, campaigns, documentations, handy articles and much more.
 
-:fontawesome-solid-book: [Liquidty Mining related blog posts](https://hummingbot.io/en/blog/tag/liquidity-mining/)
-
-:fontawesome-solid-book: [Demystifying liquidity mining rewards](https://hummingbot.io/en/blog/2019-12-liquidity-mining-rewards)
+:fontawesome-solid-book: [Demystifying liquidity mining rewards](https://hummingbot.io/blog/2019-12-liquidity-mining-rewards)
 
 :fontawesome-brands-youtube: [Liquidity Mining Explained | For New Users](https://www.youtube.com/watch?v=ME5osB8sX_s): Learn about Liquidity Mining and how to set up a market-making bot to earn rewards in an exchange.
 
-*Check out [Hummingbot Academy](https://hummingbot.io/en/academy) for more resources related to this strategy and others!*
+*Check out [Hummingbot Academy](https://hummingbot.io/academy) for more resources related to this strategy and others!*

--- a/docs/strategies/perpetual-market-making.md
+++ b/docs/strategies/perpetual-market-making.md
@@ -72,13 +72,13 @@ Similar to the `pure_market_making_strategy`, the `perpetual_market_making` stra
 
 The `perpetual_market_making` strategy works in a similar fashion as the `pure_market_making_strategy`, except adapted to trading perpetual swaps. Trading perpetual swaps creates positions, and doesn't just exchage assets like trading on spot markets.
 
-On every tick the strategy creates new opening orders and existing orders are being cancelled. If an outstanding order is filled, the strategy then has to manage the position. 
+On every tick the strategy creates new opening orders and existing orders are being cancelled. If an outstanding order is filled, the strategy then has to manage the position.
 
 ![Figure 1: General strategy flow chart](/assets/img/perp_mm-flowchart-1.svg)
 
 ### Order Placement
 
-The strategy places long and short orders to open perpetual swap positions at predefined distances from a mid price. These distances are given by the parameters `bid_spread` and `ask_spread`. 
+The strategy places long and short orders to open perpetual swap positions at predefined distances from a mid price. These distances are given by the parameters `bid_spread` and `ask_spread`.
 
 On every tick, outstanding open orders are being evaluated. If they're too far from the proposal orders, as defined by the `order_refresh_tolerance_pct` parameter, they will be cancelled and replaced by new orders.
 If an active order finds itself below a `min_spread` threshold from the mid price, it will also be cancelled.
@@ -99,4 +99,4 @@ New opening orders are not being placed if one or more of existing opening order
 
 :fontawesome-brands-youtube: [Perpetual Market Making Demo | Hummingbot Live](https://www.youtube.com/watch?v=IclhZWtKiSA): Demo of the Perpetual Market Making strategy
 
-*Check out [Hummingbot Academy](https://hummingbot.io/en/academy) for more resources related to this strategy and others!*
+*Check out [Hummingbot Academy](https://hummingbot.io/academy) for more resources related to this strategy and others!*

--- a/docs/strategies/pure-market-making.md
+++ b/docs/strategies/pure-market-making.md
@@ -259,4 +259,4 @@ Currently, only the following parameters can be reconfigured without stopping th
 
 :fontawesome-solid-book: [Pure Market Making (PMM) Strategy](https://blog.hummingbot.org/academy-level-2-c-beginner-strategy-1-pure-market-making-pmm-strategy/): Use Pure Market Making Strategy but set dynamic bid/ask orders based on TradingView indicators which trigger alerts to Telegram and change the bid/ask orders using inventory skew or spreads-adjusted.
 
-*Check out [Hummingbot Academy](https://hummingbot.io/en/academy) for more resources related to this strategy and others!*
+*Check out [Hummingbot Academy](https://hummingbot.io/academy) for more resources related to this strategy and others!*

--- a/docs/strategies/spot-perpetual-arbitrage.md
+++ b/docs/strategies/spot-perpetual-arbitrage.md
@@ -53,4 +53,4 @@ Open
 
 :fontawesome-brands-youtube: [Spot-Perpetual Arbitrage Strategy Demo | Hummingbot Live](https://www.youtube.com/watch?v=hJPmAy-Ellk): A live demo on how you can set parameters to run the spot-perpetual arbitrage strategy
 
-*Check out [Hummingbot Academy](https://hummingbot.io/en/academy) for more resources related to this strategy and others!*
+*Check out [Hummingbot Academy](https://hummingbot.io/academy) for more resources related to this strategy and others!*

--- a/docs/strategies/twap.md
+++ b/docs/strategies/twap.md
@@ -10,7 +10,7 @@ tags:
 
 ## 📝 Summary
 
-This strategy is a simple bot that places a series of limit orders on an exchange, while allowing users to control order size, price, and duration. 
+This strategy is a simple bot that places a series of limit orders on an exchange, while allowing users to control order size, price, and duration.
 
 We recommend this strategy as a starting point for developers looking to build their own strategies, and it is used as reference for articles in [Developer Reference: Strategies](/developers/strategies).
 
@@ -26,7 +26,6 @@ We recommend this strategy as a starting point for developers looking to build t
 ## 🛠️ Strategy configs
 
 [Config map](https://github.com/hummingbot/hummingbot/blob/master/hummingbot/strategy/twap/twap_config_map.py)
-
 
 | Parameter                    | Type        | Default     | Prompt New? | Prompt                                                 |
 |------------------------------|-------------|-------------|-------------|--------------------------------------------------------|
@@ -102,6 +101,6 @@ TWAP processes orders when there is a remaining order quantity & the specified t
 
 ## ℹ️ More Resources
 
-:fontawesome-solid-book: [Strategy coding for dummies](https://hummingbot.io/blog/2022-03-26-strategy-coding-for-dummies): This article is a blog post submission from our of our users. It is not directly related to TWAP strategy, but it demos how you can write a custom script for cross exchange market making strategy 
+:fontawesome-solid-book: [Strategy coding for dummies](https://hummingbot.io/blog/2022-03-26-strategy-coding-for-dummies): This article is a blog post submission from our of our users. It is not directly related to TWAP strategy, but it demos how you can write a custom script for cross exchange market making strategy
 
-*Check out [Hummingbot Academy](https://hummingbot.io/en/academy) for more resources related to this strategy and others!*
+*Check out [Hummingbot Academy](https://hummingbot.io/academy) for more resources related to this strategy and others!*

--- a/docs/strategies/uniswap-v3-lp.md
+++ b/docs/strategies/uniswap-v3-lp.md
@@ -20,6 +20,7 @@ This strategy creates and maintains Uniswap positions as the market price change
 [`uniswap`](/gateway/exchanges/uniswap/)
 
 To use this connector, run:
+
 ```
 gateway connect uniswapLP
 ```
@@ -41,7 +42,7 @@ gateway connect uniswapLP
 | `base_token_amount`          | decimal     |             | True        | How much of your base token do you want to use for the buy position? |
 | `quote_token_amount`         | decimal     |             | True        | How much of your quote token do you want to use for the sell position? |
 | `min_profitability`          | decimal     |             | True        | What is the minimum profitability for each position is be adjusted? (Enter 1 to indicate 1%)|
-| `use_volatility`             | bool        |  False      | False       | Do you want to use price volatility to adjust spreads? (Yes/No)| 
+| `use_volatility`             | bool        |  False      | False       | Do you want to use price volatility to adjust spreads? (Yes/No)|
 | `volatility_period`          | int         |  1          | False       | Enter how long (in hours) do you want to use for price volatility calculation |
 | `volatility_factor`          | decimal     |  1.00       | False       | Enter the multiplier applied to price volatility |
 
@@ -58,14 +59,14 @@ gateway connect uniswapLP
 3. Fetch the current mid price of the pool (`last_price`)
 3. If `use_volatility` is True, the bot will calculate the price volatility used to widen spreads
 4. If the pool is valid, the bot will create two starting positions:
-    - The SELL position with:
-        - Amount of tokens added to the position = `base_token_amount`
-        - `upper_price` = `(1 + sell_spread) * last_price` 
-        - `lower_price` = `last_price`
-    - The BUY position with:
-        - Amount of tokens added to the position = `quote_token_amount`
-        - `upper_price` = `last_price`
-        - `lower_price` = `(1 - buy_spread) * last_price`
+    * The SELL position with:
+        * Amount of tokens added to the position = `base_token_amount`
+        * `upper_price` = `(1 + sell_spread) * last_price`
+        * `lower_price` = `last_price`
+    * The BUY position with:
+        * Amount of tokens added to the position = `quote_token_amount`
+        * `upper_price` = `last_price`
+        * `lower_price` = `(1 - buy_spread) * last_price`
 
 ![image.png](/assets/img/uniswap-v3-1.png)
 
@@ -78,9 +79,9 @@ Each tick, the bot monitors the pool mid price (`last_price`) and compare it to 
 **`last_price` is higher than `upper_price` of `total_position_range`**
 
 1. Create a new SELL liquidity position, using the following values:
-    - Amount of tokens of the new position = `base_token_amount`
-    - Top price bound = `(1 + sell_spread) * last_price`
-    - Lower price bound = `last_price`
+    * Amount of tokens of the new position = `base_token_amount`
+    * Top price bound = `(1 + sell_spread) * last_price`
+    * Lower price bound = `last_price`
 2. Update `total_position_range`: `upper_price = (1 + sell_spread) * last_price`
 
 ![image.png](/assets/img/uniswap-v3-2.png)
@@ -88,21 +89,20 @@ Each tick, the bot monitors the pool mid price (`last_price`) and compare it to 
 **`last_price` is lower than `lower_price` of `total_position_range`**
 
 1. Create a new BUY liquidity position, using the following values:
-    - Amount of tokens of the new position = `quote_token_amount`
-    - New position upper price = `last_price`
-    - New position lower price = `(1 - buy_spread) * last_price`
+    * Amount of tokens of the new position = `quote_token_amount`
+    * New position upper price = `last_price`
+    * New position lower price = `(1 - buy_spread) * last_price`
 2. Update `total_position_range`: `lower_price = (1 - buy_spread) * last_price`
 
 ![image.png](/assets/img/uniswap-v3-3.png)
 
 ### Important Notes
 
-- Currently, the strategy does not remove existing positions. The user should do it manually through the Uniswap interace (https://app.uniswap.org/#/pool).
-- The `status` command shows the current profitability of each position, using the `quote` asset as reference
-
+* Currently, the strategy does not remove existing positions. The user should do it manually through the Uniswap interace (<https://app.uniswap.org/#/pool>).
+* The `status` command shows the current profitability of each position, using the `quote` asset as reference
 
 ## ℹ️ More Resources
 
 :fontawesome-brands-youtube: [Uniswap V3 strategy preview | Hummingbot Live](https://www.youtube.com/watch?v=6cI3ftwBiUI): Demo of the latest iteration of Uniswap V3 strategy
 
-*Check out [Hummingbot Academy](https://hummingbot.io/en/academy) for more resources related to this strategy and others!*
+*Check out [Hummingbot Academy](https://hummingbot.io/academy) for more resources related to this strategy and others!*


### PR DESCRIPTION
- remove /en from hummingbot.io links
- remove reference to `https://hummingbot.io/en/blog/tag/liquidity-mining/` link