### PR TITLE
revise doc for mac install

### DIFF
--- a/docs/installation/source.md
+++ b/docs/installation/source.md
@@ -10,7 +10,7 @@ You can install Source and Hummingbot by selecting the following options below:
 
 ## Linux/Ubuntu
 
-_Supported versions: 16.04 LTS, 18.04 LTS, 19.04_
+_Supported versions: 18.04 LTS, 19.04 LTS, 20.04_
 
 === "Scripts"
 
@@ -54,7 +54,9 @@ _Supported versions: 16.04 LTS, 18.04 LTS, 19.04_
 
 ## MacOS
 
-### Xcode command line tools
+### Prerequisites
+
+#### Xcode command line tools
 
 Running Hummingbot on **macOS** requires [Xcode](https://developer.apple.com/xcode/) and Xcode command line tools.
 
@@ -62,16 +64,24 @@ Running Hummingbot on **macOS** requires [Xcode](https://developer.apple.com/xco
 xcode-select --install
 ```
 
-### Anaconda
+#### Anaconda
 
 Hummingbot requires Python 3 and other Python libraries. To manage these dependencies, Hummingbot uses Anaconda, an open-source environment, and package manager for Python that is the current industry standard for data scientists and data engineers.
 
-To install Anaconda, go to [the Anaconda site](https://www.anaconda.com/distribution/) and download the **Python 3.7 installer** for your operating system. Both the graphical installer and the command line installer will work. Run the installer, and it will guide you through the installation process.
-
-Afterward, open a Terminal window and try the `conda` command. If the command is valid, then Anaconda has been successfully installed, even if the graphical installer says that it failed.
+To install Anaconda, go to [the Anaconda site](https://www.anaconda.com/products/distribution#Downloads) and download and install the latest Python installer applicable for your architecture (M1 / x86-64). Both the graphical installer (.pkg) and the command line installer (.sh) will work.
 
 !!! warning
     If you use ZSH or another Unix shell, copy the code snippet below to your `.zshrc` or similar file. By default, Anaconda only adds it to your `.bash_profile` file. This makes the `conda` command available in your root path.
+
+    We also do **NOT** recommend installing `conda` through `Homebrew` as this will cause issues during installation. Downloading directly from the Anaconda website should be sufficient. 
+
+Open a terminal window and run `nano` to edit the `.zshrc` file
+
+```
+nano .zshrc
+```
+
+Copy and paste the following code below:
 
 ```
 __conda_setup="$(CONDA_REPORT_ERRORS=false '/anaconda3/bin/conda' shell.bash hook 2> /dev/null)"
@@ -88,25 +98,49 @@ fi
 unset __conda_setup
 ```
 
-### Hummingbot
+Exit out of `nano` and make sure to save the changes then close & relaunch the terminal. Once you have the terminal up run the `conda init` command.
 
 ```
-# 1) Clone Hummingbot repo
+conda init zsh
+```
+
+Afterward, you can also try the `conda` command in a terminal to verify if conda was installed correctly. If the command is valid, then Anaconda has been successfully installed. Proceed to the next step to install Hummingbot
+
+#### Install Hummingbot
+
+Clone Hummingbot repo
+
+```
 git clone https://github.com/hummingbot/hummingbot.git
+```
 
-# 2) Navigate into the hummingbot folder
+Navigate into the hummingbot folder
+
+```
 cd hummingbot
+```
 
-# 3) Run install script
+Run install script
+
+```
 ./install
+```
 
-# 4) Activate the environment
+Activate the environment
+
+```
 conda activate hummingbot
+```
 
-# 5) Compile
+Compile
+
+```
 ./compile
+```
 
-# 6) Run Hummingbot
+Run Hummingbot
+
+```
 bin/hummingbot.py
 ```
 


### PR DESCRIPTION
- added note about not using Homebrew and downloading instead directly from Anaconda website
- added each command into individual code blocks and removed the comments to make it easier for users to copy - paste the commands. They can just click the copy icon at the top right of the code block to copy the whole block and then paste into the terminal