### PR TITLE
fix /broken link in quickstart guide

### DIFF
--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -102,7 +102,7 @@ To get started with Hummingbot, check out the following docs:
 
 * [Post Installation](./post-installation.md)
 * [Basic Features](/client/)
-* [Quickstart Guide](../getting-started/#quickstart-guides)
+* [Quickstart Guide](/getting-started/#quickstart-guides)
 * [Hummingbot FAQ](/faq/)
 
 If you need to run DEX bots, install [Hummingbot Gateway](/gateway).

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -102,7 +102,7 @@ To get started with Hummingbot, check out the following docs:
 
 * [Post Installation](./post-installation.md)
 * [Basic Features](/client/)
-* [Quickstart Guide](../getting-started/custom-script/index.md)
+* [Quickstart Guide](../getting-started/#quickstart-guides)
 * [Hummingbot FAQ](/faq/)
 
 If you need to run DEX bots, install [Hummingbot Gateway](/gateway).


### PR DESCRIPTION
Fix for #269 

https://hummingbot.org/installation/getting-started/custom-script/index.md


![image](https://github.com/hummingbot/hummingbot-site/assets/83953535/41117750-dca4-4b05-b1a4-589bb88983e2)

