### PR TITLE
Replace '2MN3UWg' with 'hummingbot'

### DIFF
--- a/docs/operation/log-files.md
+++ b/docs/operation/log-files.md
@@ -25,4 +25,4 @@ the oldest ones will be deleted in order to limit disk storage usage.
 The log rotation feature was added in [Hummingbot version 0.17.0](https://docs.hummingbot.io/release-notes/0.17.0/#log-file-management-data-storage).
 
 If you are looking for support in handling errors or have questions about behavior reported in logs,
-you can find ways of contacting the team or community in our [support section](https://discord.com/invite/2MN3UWg).
+you can find ways of contacting the team or community in our [support section](https://discord.com/invite/hummingbot).


### PR DESCRIPTION
### Issue
Closes #285

### Description
This pull request addresses the issue related to the presence of a malicious Discord invite link. The link [https://discord.com/invite/2MN3UWg](https://discord.com/invite/2MN3UWg) has been identified as harmful, and this change aims to replace it with the correct and safe link [https://discord.com/invite/hummingbot](https://discord.com/invite/hummingbot).

### Changes Made
- Replaced the malicious Discord invite link.
- Ensured all affected files are updated.

### Additional Context
This change is critical to maintaining the security and integrity of our project. Please review and provide feedback.