### PR TITLE
Docs/simplify magic link syntax

### DIFF
--- a/docs/installation/raspberry-pi.md
+++ b/docs/installation/raspberry-pi.md
@@ -5,7 +5,7 @@
 ### Prerequisites
 
 !!! note
-    This installation method is currently under testing and awaiting feedback from users. Should you run into problems or have found a fix to solve errors along the way, feel free to reach out through our [Discord](https://discord.com/invite/2MN3UWg) support channel.
+    This installation method is currently under testing and awaiting feedback from users. Should you run into problems or have found a fix to solve errors along the way, feel free to reach out through our [Discord](https://discord.com/invite/hummingbot) support channel.
 
 **Install Docker and change permissions**
 

--- a/docs/maintenance/index.md
+++ b/docs/maintenance/index.md
@@ -36,7 +36,7 @@ The Foundation will charge Sponsors a fee in order to administer the program and
 
 | Contributor                                        | Contribution                                               | Bounty   | Amount     |
 |----------------------------------------------------|------------------------------------------------------------|--------- | ---------- |
-| [leastchaos](https://github.com/leastchaos)        | [#4121](https://github.com/hummingbot/hummingbot/pull/4121) | Strategy | $10,000    |
+| [leastchaos](https://github.com/leastchaos)        | !4121 | Strategy | $10,000    |
 | [cryptoulette](https://twitter.com/cryptoulette)   | [guide](https://docs.google.com/document/d/1CuMFk7DalTUUvpDkzI9-72nC8WFre3CW/edit?usp=sharing&ouid=106910946131072781869&rtpof=true&sd=true) + [video](https://www.youtube.com/watch?v=T1rsNcFD5Cw) | Content | $2,000 |
 
 The winning [`hedge`](/strategies/hedge/) strategy was merged in version [0.45.0](/release-notes/0.45.0/).
@@ -51,7 +51,7 @@ The winning [`hedge`](/strategies/hedge/) strategy was merged in version [0.45.0
 
 | Contributor                                        | Contribution                                               | Bounty   | Amount     |
 |----------------------------------------------------|------------------------------------------------------------|--------- | ---------- |
-| [squarelover](https://github.com/squarelover)      | [#3430](https://github.com/hummingbot/hummingbot/pull/3430) | Strategy | $2,000     |
+| [squarelover](https://github.com/squarelover)      | !3430 | Strategy | $2,000     |
 
 The winning [`aroon-oscillator`](/strategies/aroon-oscillator/) strategy was merged in version [0.45.0](/release-notes/0.45.0/).
 

--- a/docs/operation/log-files.md
+++ b/docs/operation/log-files.md
@@ -25,4 +25,4 @@ the oldest ones will be deleted in order to limit disk storage usage.
 The log rotation feature was added in [Hummingbot version 0.17.0](https://docs.hummingbot.io/release-notes/0.17.0/#log-file-management-data-storage).
 
 If you are looking for support in handling errors or have questions about behavior reported in logs,
-you can find ways of contacting the team or community in our [support section](https://discord.com/invite/2MN3UWg).
+you can find ways of contacting the team or community in our [support section](https://discord.com/invite/hummingbot).

--- a/docs/release-notes/0.15.0.md
+++ b/docs/release-notes/0.15.0.md
@@ -36,10 +36,10 @@ We implemented a number of changes to the cross exchange market making strategy 
 Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
 * Remove requirements to maintain Ethereum balance to be eligibe to receive bounties
-* Fix telegram `history`, which was truncating data: [#743](https://github.com/hummingbot/hummingbot/issues/743)
-* Fix cancel/cancel all bug in Huobi connector: [#750](https://github.com/hummingbot/hummingbot/issues/750)
+* Fix telegram `history`, which was truncating data: #743
+* Fix cancel/cancel all bug in Huobi connector: #750
 * Increase delay (0.3s to 1s) on Binance snapshot request to avoid rate limit errors
-* Fix excessive error warnings in cross exchange market making strategy due to insufficient balance: [#773](https://github.com/hummingbot/hummingbot/issues/773)
+* Fix excessive error warnings in cross exchange market making strategy due to insufficient balance: #773
 * Removed excessive `API call error` warnings
 * Fix bug showing duplicate assets due to case sensitivity (e.g. treating ETH and eth as different assets)
 

--- a/docs/release-notes/0.16.0.md
+++ b/docs/release-notes/0.16.0.md
@@ -34,9 +34,9 @@ As part of our ongoing efforts to make the Hummingbot code base more understanda
 
 Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
-* Fixed assets showing 0 value in Huobi: [#826](https://github.com/hummingbot/hummingbot/issues/826)
-* Fixed Discovery strategy not showing profitability and optimization for Huobi: [#825](https://github.com/hummingbot/hummingbot/issues/825)
-* Fixed issue with cross-exchange strategy not placing maker orders if order book is empty: [#854](https://github.com/hummingbot/hummingbot/issues/854)
+* Fixed assets showing 0 value in Huobi: #826
+* Fixed Discovery strategy not showing profitability and optimization for Huobi: #825
+* Fixed issue with cross-exchange strategy not placing maker orders if order book is empty: #854
 * Added `exchange_trade_id` to all OrderFilledEvent in Huobi, IDEX, Radar and Coinbase as part of our efforts to standardize all TradeFill data sent to bounty server and check the websocket API to ensure all trades can be validated.
 
 ## 🚀 Coming soon

--- a/docs/release-notes/0.17.0.md
+++ b/docs/release-notes/0.17.0.md
@@ -33,12 +33,12 @@ We published a developer tutorial on building custom strategies and documentatio
 
 Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
-* Fixed IDEX minimum ETH wallet check: [#845](https://github.com/hummingbot/hummingbot/issues/845)
-* Fixed bug related to paper trading mode account balance: [#843](https://github.com/hummingbot/hummingbot/issues/843)
-* Fixed run time warning error when restarting strategy after sending a list config command: [#828](https://github.com/hummingbot/hummingbot/issues/828)
-* Fixed bug where trades were not being tracked for a bounty: [#918](https://github.com/hummingbot/hummingbot/issues/918)
-* Fixed code bug in DDEX market: [#923](https://github.com/hummingbot/hummingbot/issues/923)
-* Fixed pure market making issue with orders getting stuck in client when hanging orders feature is enabled: [#905](https://github.com/hummingbot/hummingbot/issues/905) [#914](https://github.com/hummingbot/hummingbot/issues/914)
+* Fixed IDEX minimum ETH wallet check: #845
+* Fixed bug related to paper trading mode account balance: #843
+* Fixed run time warning error when restarting strategy after sending a list config command: #828
+* Fixed bug where trades were not being tracked for a bounty: #918
+* Fixed code bug in DDEX market: #923
+* Fixed pure market making issue with orders getting stuck in client when hanging orders feature is enabled: #905 #914
 * Refactor from float to decimal order price, amount, fees, balances, profitability related calculation and config in all strategy and market connectors
 
 

--- a/docs/release-notes/0.18.0.md
+++ b/docs/release-notes/0.18.0.md
@@ -23,7 +23,7 @@ Follow the links below for more information:
 ## 🤓 Developer usability
 
 * Developer documentation for [Simple Trade](/developers/strategies/tutorial/)
-* Added missing templates for dev strategies: [#960](https://github.com/hummingbot/hummingbot/pull/960)
+* Added missing templates for dev strategies: !960
 
 
 ## 🐞 Other bug fixes and miscellaneous updates

--- a/docs/release-notes/0.18.0.md
+++ b/docs/release-notes/0.18.0.md
@@ -30,11 +30,11 @@ Follow the links below for more information:
 
 Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
-* Failed to submit cancel orders in Huobi: [#750](https://github.com/hummingbot/hummingbot/issues/750)
-* Added trading pair fetcher in Bittrex to prevent issues related to entering incorrect pair format: [#985](https://github.com/hummingbot/hummingbot/issues/985)
-* Added available balances feature in Radar Relay to fix errors and issues not creating orders: [#942](https://github.com/hummingbot/hummingbot/issues/942) [#943](https://github.com/hummingbot/hummingbot/issues/943)
-* Fixed issues with performance analysis where the asset is initialized with current trading pair but the trades being analyzed can include other trading pair that causes key error during processing: [#974](https://github.com/hummingbot/hummingbot/issues/974)
-* Fixed cross-exchange strategy where `order_size_portfolio_ratio_limit` was showing `order_size_taker_balance_factor`: [#989](https://github.com/hummingbot/hummingbot/issues/989)
+* Failed to submit cancel orders in Huobi: #750
+* Added trading pair fetcher in Bittrex to prevent issues related to entering incorrect pair format: #985
+* Added available balances feature in Radar Relay to fix errors and issues not creating orders: #942 #943
+* Fixed issues with performance analysis where the asset is initialized with current trading pair but the trades being analyzed can include other trading pair that causes key error during processing: #974
+* Fixed cross-exchange strategy where `order_size_portfolio_ratio_limit` was showing `order_size_taker_balance_factor`: #989
 * Added version number to global and strategy config files to copy existing configs from an outdated file to the new one, to avoid reconfiguring API keys. Any outdated parameters will be deleted and empty ones will be prompted.
 * Reduced excessive warning messages in Bittrex exchange.
 * Unit testing for Bittrex market.

--- a/docs/release-notes/0.18.1.md
+++ b/docs/release-notes/0.18.1.md
@@ -2,4 +2,4 @@
 
 This release is a hotfix to version [0.18.0](/release-notes/0.18.0).
 
-* Added a [fix (#1035)](https://github.com/hummingbot/hummingbot/pull/1035) to parse trading pair symbols for the cross-exchange market making strategy to address a bug (#1033) that was preventing the strategy from initializing.
+* Added a fix (!1035) to parse trading pair symbols for the cross-exchange market making strategy to address a bug (#1033) that was preventing the strategy from initializing.

--- a/docs/release-notes/0.18.1.md
+++ b/docs/release-notes/0.18.1.md
@@ -2,4 +2,4 @@
 
 This release is a hotfix to version [0.18.0](/release-notes/0.18.0).
 
-* Added a [fix (#1035)](https://github.com/hummingbot/hummingbot/pull/1035) to parse trading pair symbols for the cross-exchange market making strategy to address a [bug (#1033)](https://github.com/hummingbot/hummingbot/issues/1033) that was preventing the strategy from initializing.
+* Added a [fix (#1035)](https://github.com/hummingbot/hummingbot/pull/1035) to parse trading pair symbols for the cross-exchange market making strategy to address a bug (#1033) that was preventing the strategy from initializing.

--- a/docs/release-notes/0.19.0.md
+++ b/docs/release-notes/0.19.0.md
@@ -22,7 +22,7 @@
 Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
 * Fixed orders getting stuck in Bittrex when hedging price moves too fast: #1042
-* Fixed issues with starting arbitrage strategy using incorrect trading pair: [#1062](https://github.com/hummingbot/hummingbot/pull/1062)
+* Fixed issues with starting arbitrage strategy using incorrect trading pair: !1062
 * Fixed issues when placing orders with extremely low prices on Bittrex: #1032
 * Updated Hummingbot icon to greenish blue which solves the problem of the white icon becoming invisible in white backgrounds (Windows).
 * Added more tests to coinbase_pro data source and coinbase_pro user stream tracker.

--- a/docs/release-notes/0.19.0.md
+++ b/docs/release-notes/0.19.0.md
@@ -21,9 +21,9 @@
 
 Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
-* Fixed orders getting stuck in Bittrex when hedging price moves too fast: [#1042](https://github.com/hummingbot/hummingbot/issues/1042)
+* Fixed orders getting stuck in Bittrex when hedging price moves too fast: #1042
 * Fixed issues with starting arbitrage strategy using incorrect trading pair: [#1062](https://github.com/hummingbot/hummingbot/pull/1062)
-* Fixed issues when placing orders with extremely low prices on Bittrex: [#1032](https://github.com/hummingbot/hummingbot/issues/1032)
+* Fixed issues when placing orders with extremely low prices on Bittrex: #1032
 * Updated Hummingbot icon to greenish blue which solves the problem of the white icon becoming invisible in white backgrounds (Windows).
 * Added more tests to coinbase_pro data source and coinbase_pro user stream tracker.
 * Updated the asset to ERC20 address mapping to support newer trading pairs on Bamboo Relay.

--- a/docs/release-notes/0.20.0.md
+++ b/docs/release-notes/0.20.0.md
@@ -29,15 +29,15 @@ Also, we recently released a blog explaining how liquidity mining rewards are ca
 
 Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
-* Fixed price calculation when trading BUSD stablecoin: [#1120](https://github.com/hummingbot/hummingbot/issues/1120)
-* Fixed unexpected keyword argument 'trading_pairs' in Bamboo Relay: [#1113](https://github.com/hummingbot/hummingbot/issues/1113)
-* Fixed bug in Bittrex where inventory skew creates order sizes lower than the minimum trade size/value: [#1092](https://github.com/hummingbot/hummingbot/issues/1092)
-* Fixed auto-complete bug on prompts with the word ‘exchange’ even when it’s not supposed to: [#1159](https://github.com/hummingbot/hummingbot/issues/1159)
-* Fixed errors fetching new events from ERC20 contracts when trading SAI in DDEX and Radar Relay: [#1147](https://github.com/hummingbot/hummingbot/issues/1147)
+* Fixed price calculation when trading BUSD stablecoin: #1120
+* Fixed unexpected keyword argument 'trading_pairs' in Bamboo Relay: #1113
+* Fixed bug in Bittrex where inventory skew creates order sizes lower than the minimum trade size/value: #1092
+* Fixed auto-complete bug on prompts with the word ‘exchange’ even when it’s not supposed to: #1159
+* Fixed errors fetching new events from ERC20 contracts when trading SAI in DDEX and Radar Relay: #1147
 * Fixed Bamboo Relay SSL error when running on Windows: [#1158](https://github.com/hummingbot/hummingbot/pull/1158)
-* Fixed error running performance analysis when sending history command: [#951](https://github.com/hummingbot/hummingbot/issues/951), [#1069](https://github.com/hummingbot/hummingbot/issues/1069), [1155](https://github.com/hummingbot/hummingbot/issues/1155)
-* Fixed error parsing trading pair with new token RUB in Binance: [#1184](https://github.com/hummingbot/hummingbot/issues/1184)
-* Fixed default values not working for some parameters in pure market making: [#1085](https://github.com/hummingbot/hummingbot/issues/1085)
+* Fixed error running performance analysis when sending history command: #951, #1069, [1155](https://github.com/hummingbot/hummingbot/issues/1155)
+* Fixed error parsing trading pair with new token RUB in Binance: #1184
+* Fixed default values not working for some parameters in pure market making: #1085
 * Refactored pure market making strategy’s penny jumping mode to best bid ask jumping
 * Updated Bamboo Relay changing ‘symbol’ to ‘trading_pairs’
 * Updated Dolomite changing ‘symbol’ to ‘trading_pairs’

--- a/docs/release-notes/0.20.0.md
+++ b/docs/release-notes/0.20.0.md
@@ -34,7 +34,7 @@ Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone 
 * Fixed bug in Bittrex where inventory skew creates order sizes lower than the minimum trade size/value: #1092
 * Fixed auto-complete bug on prompts with the word ‘exchange’ even when it’s not supposed to: #1159
 * Fixed errors fetching new events from ERC20 contracts when trading SAI in DDEX and Radar Relay: #1147
-* Fixed Bamboo Relay SSL error when running on Windows: [#1158](https://github.com/hummingbot/hummingbot/pull/1158)
+* Fixed Bamboo Relay SSL error when running on Windows: !1158
 * Fixed error running performance analysis when sending history command: #951, #1069, [1155](https://github.com/hummingbot/hummingbot/issues/1155)
 * Fixed error parsing trading pair with new token RUB in Binance: #1184
 * Fixed default values not working for some parameters in pure market making: #1085

--- a/docs/release-notes/0.21.0.md
+++ b/docs/release-notes/0.21.0.md
@@ -30,7 +30,7 @@ Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone 
 Here's what we currently working on that we expect to ship in the next 2-8 weeks:
 
 * Developer tutorial on building custom strategies
-* External price source for pure market-making strategy [#1249](https://github.com/hummingbot/hummingbot/pull/1249)
+* External price source for pure market-making strategy !1249
 * [KuCoin](https://www.kucoin.com/) connector
 * [Bitfinex](https://www.bitfinex.com/) connector
 * [HitBTC](https://hitbtc.com/) connector

--- a/docs/release-notes/0.21.0.md
+++ b/docs/release-notes/0.21.0.md
@@ -12,13 +12,13 @@ We are officially announcing the TWAP custom strategy, a common algorithmic exec
 
 Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
-* Fixed bug triggering kill switch due to inventory changes outside of trades: [#1145](https://github.com/hummingbot/hummingbot/issues/1145) 
-* Fixed default value not working for some parameters with pure market making strategy: [#1085](https://github.com/hummingbot/hummingbot/issues/1085)
-* Fixed running into sqlite3.IntegrityError when orders are filled in Coinbase Pro: [#1138](https://github.com/hummingbot/hummingbot/issues/1138), [#1142](https://github.com/hummingbot/hummingbot/issues/1142)
-* Fixed memory leak issue caused by hanging orders in pure market making strategy: [#1167](https://github.com/hummingbot/hummingbot/issues/1167)
-* Fixed Too aggressive API calls with hanging orders enabled: [#1246](https://github.com/hummingbot/hummingbot/issues/1246)
-* Fixed Liquid connector not working due to missing pair ETH-USDC: [#1234](https://github.com/hummingbot/hummingbot/issues/1234), [#1231](https://github.com/hummingbot/hummingbot/issues/1231)
-* Fixed available balances not being calculated correctly in Bamboo Relay: [#1238](https://github.com/hummingbot/hummingbot/issues/1238)
+* Fixed bug triggering kill switch due to inventory changes outside of trades: #1145 
+* Fixed default value not working for some parameters with pure market making strategy: #1085
+* Fixed running into sqlite3.IntegrityError when orders are filled in Coinbase Pro: #1138, #1142
+* Fixed memory leak issue caused by hanging orders in pure market making strategy: #1167
+* Fixed Too aggressive API calls with hanging orders enabled: #1246
+* Fixed Liquid connector not working due to missing pair ETH-USDC: #1234, #1231
+* Fixed available balances not being calculated correctly in Bamboo Relay: #1238
 
 * Improvements to config encryption feature
 * Minor changes to Bittrex market testing to address some failing unit tests

--- a/docs/release-notes/0.22.0.md
+++ b/docs/release-notes/0.22.0.md
@@ -30,13 +30,13 @@ Here we list recent major changes to Hummingbot docs:
 
 Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
-* Fixed issue on Windows when running pure market making strategy on multiple orders mode: [#1261](https://github.com/hummingbot/hummingbot/issues/1261)
-* Fixed generic syntax on trading pair symbols not working: [#1264](https://github.com/hummingbot/hummingbot/issues/1264)
-* Fixed unexpected errors when running pure market making with zero balance: [#1292](https://github.com/hummingbot/hummingbot/issues/1292) 
-* Fixed a bug with Dolomite during start up: [#1148](https://github.com/hummingbot/hummingbot/issues/1148)
-* Fixed websocket connection errors when using Liquid connector: [#1266](https://github.com/hummingbot/hummingbot/issues/1266)
-* Fixed clock de-sync with Binance timestamp on Windows: [#1262](https://github.com/hummingbot/hummingbot/issues/1262)
-* Fixed KeyError: ‘ETH-CNY’ on Liquid connector: [#1251](https://github.com/hummingbot/hummingbot/issues/1251)
+* Fixed issue on Windows when running pure market making strategy on multiple orders mode: #1261
+* Fixed generic syntax on trading pair symbols not working: #1264
+* Fixed unexpected errors when running pure market making with zero balance: #1292 
+* Fixed a bug with Dolomite during start up: #1148
+* Fixed websocket connection errors when using Liquid connector: #1266
+* Fixed clock de-sync with Binance timestamp on Windows: #1262
+* Fixed KeyError: ‘ETH-CNY’ on Liquid connector: #1251
 
 
 ## ⚙️ Miscellaneous updates

--- a/docs/release-notes/0.22.0.md
+++ b/docs/release-notes/0.22.0.md
@@ -54,7 +54,7 @@ Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone 
 Here's what we currently working on that we expect to ship in the next 2-8 weeks:
 
 * Developer tutorial on building custom strategies
-* [KuCoin](https://www.kucoin.com/) connector (in progress [#1223](https://github.com/hummingbot/hummingbot/pull/1223), [#1171](https://github.com/hummingbot/hummingbot/pull/1171))
-* [Bitfinex](https://www.bitfinex.com/) connector (in progress [#1227](https://github.com/hummingbot/hummingbot/pull/1227), [#1237](https://github.com/hummingbot/hummingbot/pull/1237))
-* [HitBTC](https://hitbtc.com/) connector (in progress [#1224](https://github.com/hummingbot/hummingbot/pull/1224))
+* [KuCoin](https://www.kucoin.com/) connector (in progress !1223, !1171)
+* [Bitfinex](https://www.bitfinex.com/) connector (in progress !1227, !1237)
+* [HitBTC](https://hitbtc.com/) connector (in progress !1224)
 * [gate.io](https://gate.io) connector

--- a/docs/release-notes/0.23.0.md
+++ b/docs/release-notes/0.23.0.md
@@ -67,11 +67,11 @@ Here we list other recent major changes to Hummingbot docs:
 
 Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
-* Fixed error when exporting trades in Windows: [#1302](https://github.com/hummingbot/hummingbot/issues/1302)
-* Fixed bug losing track of orders on Coinbase Pro: [#1357](https://github.com/hummingbot/hummingbot/issues/1357)
-* Fixed bug where Hummingbot keeps fetching status of non-existing orders in client: [#1281](https://github.com/hummingbot/hummingbot/issues/1281)
-* Fixed bug in Liquid connector on non-fiat quote asset: [#1331](https://github.com/hummingbot/hummingbot/issues/1331)
-* Fixed intermittent index errors with pure market making strategy causing orders not created: [#1317](https://github.com/hummingbot/hummingbot/issues/1317)
+* Fixed error when exporting trades in Windows: #1302
+* Fixed bug losing track of orders on Coinbase Pro: #1357
+* Fixed bug where Hummingbot keeps fetching status of non-existing orders in client: #1281
+* Fixed bug in Liquid connector on non-fiat quote asset: #1331
+* Fixed intermittent index errors with pure market making strategy causing orders not created: #1317
 
 
 ## ⚙️ Miscellaneous updates

--- a/docs/release-notes/0.23.0.md
+++ b/docs/release-notes/0.23.0.md
@@ -87,6 +87,6 @@ Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone 
 
 Here's what we currently working on that we expect to ship in the next 2-8 weeks:
 
-* [Bitfinex](https://www.bitfinex.com/) connector (in progress [#1227](https://github.com/hummingbot/hummingbot/pull/1227), [#1237](https://github.com/hummingbot/hummingbot/pull/1237))
-* [HitBTC](https://hitbtc.com/) connector (in progress [#1224](https://github.com/hummingbot/hummingbot/pull/1224))
+* [Bitfinex](https://www.bitfinex.com/) connector (in progress !1227, !1237)
+* [HitBTC](https://hitbtc.com/) connector (in progress !1224)
 * [gate.io](https://gate.io) connector

--- a/docs/release-notes/0.24.0.md
+++ b/docs/release-notes/0.24.0.md
@@ -31,9 +31,9 @@ Here we list other recent major changes to Hummingbot docs:
 
 Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone who reports a bug that we end up fixing.**
 
-* Fixed error when exporting trades in Windows: [#1302](https://github.com/hummingbot/hummingbot/issues/1302)
-* Added reduced polling logic for Binance API limit: [#1379](https://github.com/hummingbot/hummingbot/issues/1379)
-* Fixed Binance clock desync in Windows resulting to problems with orders: [#1388](https://github.com/hummingbot/hummingbot/issues/1388)
+* Fixed error when exporting trades in Windows: #1302
+* Added reduced polling logic for Binance API limit: #1379
+* Fixed Binance clock desync in Windows resulting to problems with orders: #1388
 
 ## 🈲 Exchange Deprecation - DDEX and IDEX
 

--- a/docs/release-notes/0.24.0.md
+++ b/docs/release-notes/0.24.0.md
@@ -45,6 +45,6 @@ We are making DDEX and IDEX exchange connectors as deprecated. The connector cod
 Here's what we currently working on that we expect to ship in the next 2-8 weeks:
 
 * [Bitfinex](https://www.bitfinex.com/) connector (in progress)
-* [Kraken](https://www.kraken.com/) connector (in progress [#1454](https://github.com/hummingbot/hummingbot/pull/1454))
-* [HitBTC](https://hitbtc.com/) connector (in progress [#1224](https://github.com/hummingbot/hummingbot/pull/1224))
+* [Kraken](https://www.kraken.com/) connector (in progress !1454)
+* [HitBTC](https://hitbtc.com/) connector (in progress !1224)
 * [gate.io](https://gate.io) connector

--- a/docs/release-notes/0.24.1.md
+++ b/docs/release-notes/0.24.1.md
@@ -2,8 +2,8 @@
 
 This release is a hotfix to version [0.24.0](/release-notes/0.24.0).
 
-* Added a [fix (#1481)](https://github.com/hummingbot/hummingbot/pull/1481) in configuration module to address a [bug (#1100)](https://github.com/hummingbot/hummingbot/issues/1473) that was preventing bot restart.
+* Added a fix (!1481) in configuration module to address a [bug (#1100)](https://github.com/hummingbot/hummingbot/issues/1473) that was preventing bot restart.
 
-* Added a [fix (#1472)](https://github.com/hummingbot/hummingbot/pull/1472) in configuration module to address a bug that was preventing trading pair autocomplete.
+* Added a fix (!1472) in configuration module to address a bug that was preventing trading pair autocomplete.
 
-* Added a [fix (#1470)](https://github.com/hummingbot/hummingbot/pull/1470) in exchange rate conversion module to address a bug (#1469) in coin gecko exchange rate errors.
+* Added a fix (!1470) in exchange rate conversion module to address a bug (#1469) in coin gecko exchange rate errors.

--- a/docs/release-notes/0.24.1.md
+++ b/docs/release-notes/0.24.1.md
@@ -6,4 +6,4 @@ This release is a hotfix to version [0.24.0](/release-notes/0.24.0).
 
 * Added a [fix (#1472)](https://github.com/hummingbot/hummingbot/pull/1472) in configuration module to address a bug that was preventing trading pair autocomplete.
 
-* Added a [fix (#1470)](https://github.com/hummingbot/hummingbot/pull/1470) in exchange rate conversion module to address a [bug (#1469)](https://github.com/hummingbot/hummingbot/issues/1469) in coin gecko exchange rate errors.
+* Added a [fix (#1470)](https://github.com/hummingbot/hummingbot/pull/1470) in exchange rate conversion module to address a bug (#1469) in coin gecko exchange rate errors.

--- a/docs/release-notes/0.25.0.md
+++ b/docs/release-notes/0.25.0.md
@@ -71,6 +71,6 @@ Here's what we currently working on that we expect to ship in the next 2-8 weeks
 
 **Hummingbot client**
 
-* [Bitfinex](https://www.bitfinex.com/) connector (in progress [#1482](https://github.com/hummingbot/hummingbot/pull/1482))
-* [Kraken](https://www.kraken.com/) connector (in progress [#1454](https://github.com/hummingbot/hummingbot/pull/1454))
-* [HitBTC](https://hitbtc.com/) connector (in progress [#1224](https://github.com/hummingbot/hummingbot/pull/1224))
+* [Bitfinex](https://www.bitfinex.com/) connector (in progress !1482)
+* [Kraken](https://www.kraken.com/) connector (in progress !1454)
+* [HitBTC](https://hitbtc.com/) connector (in progress !1224)

--- a/docs/release-notes/0.25.0.md
+++ b/docs/release-notes/0.25.0.md
@@ -50,7 +50,7 @@ In addition to these advanced features, we also changed the default values of th
 
 ## 🐞 Other bug fixes
 
-* Fixed Hummingbot resetting to a command line screen when errors are shown: [#1519](https://github.com/hummingbot/hummingbot/issues/1519)
+* Fixed Hummingbot resetting to a command line screen when errors are shown: #1519
 
 
 ## ⚙️ Miscellaneous updates

--- a/docs/release-notes/0.26.0.md
+++ b/docs/release-notes/0.26.0.md
@@ -49,11 +49,11 @@ The Telegram integration now has a smaller keyboard that doesn't block the main 
 ## 🐞 Bug fixes
 
 * Added Microsoft Visual C++ redist package as part of the setup process to fix binary installer for Windows: [#1598](https://github.com/hummingbot/hummingbot/pull/1598)
-* Fixed broken trading pair fetcher in Radar Relay: [#1441](https://github.com/hummingbot/hummingbot/issues/1441)
-* Fixed Bittrex connector failing to initialize markets: [#1534](https://github.com/hummingbot/hummingbot/issues/1534)
-* Fixed incorrect price precision on some BTC pairs in Binance while paper trading that results to bad orders: [#1618](https://github.com/hummingbot/hummingbot/issues/1618), [#1617](https://github.com/hummingbot/hummingbot/issues/1617)
-* Fixed error invalid value `[]` when using discovery strategy: [#1587](https://github.com/hummingbot/hummingbot/issues/1587)
-* Fixed how `history` shows prices of executed trades in Liquid connector: [#1415](https://github.com/hummingbot/hummingbot/issues/1415), [#1589](https://github.com/hummingbot/hummingbot/issues/1589)
+* Fixed broken trading pair fetcher in Radar Relay: #1441
+* Fixed Bittrex connector failing to initialize markets: #1534
+* Fixed incorrect price precision on some BTC pairs in Binance while paper trading that results to bad orders: #1618, #1617
+* Fixed error invalid value `[]` when using discovery strategy: #1587
+* Fixed how `history` shows prices of executed trades in Liquid connector: #1415, #1589
 
 
 ## 🚀 Coming soon

--- a/docs/release-notes/0.26.0.md
+++ b/docs/release-notes/0.26.0.md
@@ -48,7 +48,7 @@ The Telegram integration now has a smaller keyboard that doesn't block the main 
 
 ## 🐞 Bug fixes
 
-* Added Microsoft Visual C++ redist package as part of the setup process to fix binary installer for Windows: [#1598](https://github.com/hummingbot/hummingbot/pull/1598)
+* Added Microsoft Visual C++ redist package as part of the setup process to fix binary installer for Windows: !1598
 * Fixed broken trading pair fetcher in Radar Relay: #1441
 * Fixed Bittrex connector failing to initialize markets: #1534
 * Fixed incorrect price precision on some BTC pairs in Binance while paper trading that results to bad orders: #1618, #1617
@@ -61,4 +61,4 @@ The Telegram integration now has a smaller keyboard that doesn't block the main 
 Here's what we currently working on that we expect to ship in the 1-2 releases:
 
 * Improved order refresh logic to avoid hitting exchange rate limits when placing many orders
-* [Bitfinex](https://www.bitfinex.com/) connector (in progress [#1482](https://github.com/hummingbot/hummingbot/pull/1482))
+* [Bitfinex](https://www.bitfinex.com/) connector (in progress !1482)

--- a/docs/release-notes/0.26.1.md
+++ b/docs/release-notes/0.26.1.md
@@ -2,4 +2,4 @@
 
 This release is a hotfix to version [0.26.0](/release-notes/0.26.0).
 
-* Added a [fix (#1732)](https://github.com/hummingbot/hummingbot/pull/1732) in configuration module to address a [bug (#1731)](https://github.com/hummingbot/hummingbot/issues/1731) that caused bot to spam trading error.
+* Added a [fix (#1732)](https://github.com/hummingbot/hummingbot/pull/1732) in configuration module to address a bug (#1731) that caused bot to spam trading error.

--- a/docs/release-notes/0.26.1.md
+++ b/docs/release-notes/0.26.1.md
@@ -2,4 +2,4 @@
 
 This release is a hotfix to version [0.26.0](/release-notes/0.26.0).
 
-* Added a [fix (#1732)](https://github.com/hummingbot/hummingbot/pull/1732) in configuration module to address a bug (#1731) that caused bot to spam trading error.
+* Added a fix (!1732) in configuration module to address a bug (#1731) that caused bot to spam trading error.

--- a/docs/release-notes/0.27.0.md
+++ b/docs/release-notes/0.27.0.md
@@ -15,7 +15,7 @@ This feature should help users create more custom bots and manage exchange rate 
 
 ## 📊 Price Band
 
-In [#1713](https://github.com/hummingbot/hummingbot/issues/1713), we introduce two new parameters in the Pure Market Making (PMM) strategy: `price_ceiling` and `price_floor`. These parameters allow you set a price band within which your bot acts normally, but the bot behaves differently if the market price moves out of the band.
+In #1713, we introduce two new parameters in the Pure Market Making (PMM) strategy: `price_ceiling` and `price_floor`. These parameters allow you set a price band within which your bot acts normally, but the bot behaves differently if the market price moves out of the band.
 
 This feature should help users express a view that the market will stay range-bound. See [Price Band](/strategy-configs/price-band/) for more information.
 
@@ -23,11 +23,11 @@ This feature should help users express a view that the market will stay range-bo
 
 ## 🐞Fixed Memory Leak Bug
 
-We fixed a critical bug [#1683](https://github.com/hummingbot/hummingbot/issues/1683) that caused the bot to leak memory after users run the `stop` command. This caused the bot to crash unexpectedly after running for a while. This issue is now fixed.
+We fixed a critical bug #1683 that caused the bot to leak memory after users run the `stop` command. This caused the bot to crash unexpectedly after running for a while. This issue is now fixed.
 
 ## 🐙 Kraken Bug Fixes
 
-The Kraken exchange connector, which we released in `v0.26.0`, had a number of bugs. In this release, we have fixed a number of Kraken related bugs, including [#1664](https://github.com/hummingbot/hummingbot/issues/1664), [#1671](https://github.com/hummingbot/hummingbot/issues/1671), [#1676](https://github.com/hummingbot/hummingbot/issues/1676), [#1696](https://github.com/hummingbot/hummingbot/pull/1696), and [#1693](https://github.com/hummingbot/hummingbot/issues/1693).
+The Kraken exchange connector, which we released in `v0.26.0`, had a number of bugs. In this release, we have fixed a number of Kraken related bugs, including #1664, #1671, #1676, [#1696](https://github.com/hummingbot/hummingbot/pull/1696), and #1693.
 
 This connector should be much more stable going forward.
 
@@ -37,7 +37,7 @@ To fix [#1633](https://github.com/hummingbot/hummingbot/pull/1633), we now use t
 
 ## 🐞 External DB Support 
 
-After [#1596](https://github.com/hummingbot/hummingbot/issues/1596), you can hook up the Hummingbot client to external SQL databases. See [External Database](https://docs.hummingbot.io/global-configs/external-db/) for more information.
+After #1596, you can hook up the Hummingbot client to external SQL databases. See [External Database](https://docs.hummingbot.io/global-configs/external-db/) for more information.
 
 **We want to thank 🙏 community member [fengkiej](https://github.com/fengkiej) for this contribution!**
 
@@ -45,13 +45,13 @@ After [#1596](https://github.com/hummingbot/hummingbot/issues/1596), you can hoo
 * Fixed a bug in which buy and sell order refreshes could sometimes get out of sync [#1446](https://github.com/hummingbot/hummingbot/pull/1446)
 * Fixed a bug that prevented the XEMM strategy from starting [#1657](https://github.com/hummingbot/hummingbot/pull/1657)
 * Fixed a bug that prevented the `status` command from execution in paper trading mode [#1666](https://github.com/hummingbot/hummingbot/pull/1666)
-* Fixed a bug where paper trading mode didn't work on Binance due to the new `LIMIT_MAKER` order type [#1762](https://github.com/hummingbot/hummingbot/issues/1762)
-* Fixed a bug with the Inventory Skew feature where orders sometimes alternate every cycle [#1747](https://github.com/hummingbot/hummingbot/issues/1747)
-* Fixed a bug missing spreads in `status` in the XEMM strategy [#1737](https://github.com/hummingbot/hummingbot/issues/1737)
-* Fixed a bug where the version number was missing from the splash screen [#1739](https://github.com/hummingbot/hummingbot/issues/1739)
-* Fixed a bug in the Bittrex connector related to minimum order amount [#1636](https://github.com/hummingbot/hummingbot/issues/1636)
-* Fixed a bug where the version number was missing from the splash screen [#1739](https://github.com/hummingbot/hummingbot/issues/1739)
-* Removed deprecated deposit and withdrawal functions from the Binance connector [#1731](https://github.com/hummingbot/hummingbot/issues/1731)
-* Removed incorrect trading pair fetcher code from the Bittrex connector [#1700](https://github.com/hummingbot/hummingbot/issues/1700). **We want to thank 🙏 community member [aktary](https://github.com/aktary) for this contribution!**
+* Fixed a bug where paper trading mode didn't work on Binance due to the new `LIMIT_MAKER` order type #1762
+* Fixed a bug with the Inventory Skew feature where orders sometimes alternate every cycle #1747
+* Fixed a bug missing spreads in `status` in the XEMM strategy #1737
+* Fixed a bug where the version number was missing from the splash screen #1739
+* Fixed a bug in the Bittrex connector related to minimum order amount #1636
+* Fixed a bug where the version number was missing from the splash screen #1739
+* Removed deprecated deposit and withdrawal functions from the Binance connector #1731
+* Removed incorrect trading pair fetcher code from the Bittrex connector #1700. **We want to thank 🙏 community member [aktary](https://github.com/aktary) for this contribution!**
 * Fixed bugs related to input validation of the `import` command [#1704](https://github.com/hummingbot/hummingbot/pull/1704)
 * Fixed a bug with incorrect display of bot duration in `history` command [#1686](https://github.com/hummingbot/hummingbot/pull/1686)

--- a/docs/release-notes/0.27.0.md
+++ b/docs/release-notes/0.27.0.md
@@ -9,7 +9,7 @@ We're also starting to see more external contributions from the Hummingbot commu
 
 ## 🔄 Order Refresh Tolerance
 
-In [#1673](https://github.com/hummingbot/hummingbot/pull/1673), we introduce a new parameter in the Pure Market Making (PMM) strategy: `order_tolerance_refresh_pct`. This allows you to set an tolerance level for refreshing orders, so that the bot only cancels and replaces orders if the market price has moved by more than a certain threshold.
+In !1673, we introduce a new parameter in the Pure Market Making (PMM) strategy: `order_tolerance_refresh_pct`. This allows you to set an tolerance level for refreshing orders, so that the bot only cancels and replaces orders if the market price has moved by more than a certain threshold.
 
 This feature should help users create more custom bots and manage exchange rate limits better. See [Order Refresh Tolerance](/strategy-configs/order-refresh-tolerance/) for more information.
 
@@ -27,13 +27,13 @@ We fixed a critical bug #1683 that caused the bot to leak memory after users run
 
 ## 🐙 Kraken Bug Fixes
 
-The Kraken exchange connector, which we released in `v0.26.0`, had a number of bugs. In this release, we have fixed a number of Kraken related bugs, including #1664, #1671, #1676, [#1696](https://github.com/hummingbot/hummingbot/pull/1696), and #1693.
+The Kraken exchange connector, which we released in `v0.26.0`, had a number of bugs. In this release, we have fixed a number of Kraken related bugs, including #1664, #1671, #1676, !1696, and #1693.
 
 This connector should be much more stable going forward.
 
 ## ⏱ LIMIT_MAKER order type in Binance
 
-To fix [#1633](https://github.com/hummingbot/hummingbot/pull/1633), we now use the `LIMIT_MAKER` order type by default for maker orders on Binance. This order type prevents your bot from making crossed orders that would be taken automatically. This feature should help users set tight spreads more effectively.
+To fix !1633, we now use the `LIMIT_MAKER` order type by default for maker orders on Binance. This order type prevents your bot from making crossed orders that would be taken automatically. This feature should help users set tight spreads more effectively.
 
 ## 🐞 External DB Support 
 
@@ -42,9 +42,9 @@ After #1596, you can hook up the Hummingbot client to external SQL databases. Se
 **We want to thank 🙏 community member [fengkiej](https://github.com/fengkiej) for this contribution!**
 
 ## 🐞 Other Enhancements and Fixes
-* Fixed a bug in which buy and sell order refreshes could sometimes get out of sync [#1446](https://github.com/hummingbot/hummingbot/pull/1446)
-* Fixed a bug that prevented the XEMM strategy from starting [#1657](https://github.com/hummingbot/hummingbot/pull/1657)
-* Fixed a bug that prevented the `status` command from execution in paper trading mode [#1666](https://github.com/hummingbot/hummingbot/pull/1666)
+* Fixed a bug in which buy and sell order refreshes could sometimes get out of sync !1446
+* Fixed a bug that prevented the XEMM strategy from starting !1657
+* Fixed a bug that prevented the `status` command from execution in paper trading mode !1666
 * Fixed a bug where paper trading mode didn't work on Binance due to the new `LIMIT_MAKER` order type #1762
 * Fixed a bug with the Inventory Skew feature where orders sometimes alternate every cycle #1747
 * Fixed a bug missing spreads in `status` in the XEMM strategy #1737
@@ -53,5 +53,5 @@ After #1596, you can hook up the Hummingbot client to external SQL databases. Se
 * Fixed a bug where the version number was missing from the splash screen #1739
 * Removed deprecated deposit and withdrawal functions from the Binance connector #1731
 * Removed incorrect trading pair fetcher code from the Bittrex connector #1700. **We want to thank 🙏 community member [aktary](https://github.com/aktary) for this contribution!**
-* Fixed bugs related to input validation of the `import` command [#1704](https://github.com/hummingbot/hummingbot/pull/1704)
-* Fixed a bug with incorrect display of bot duration in `history` command [#1686](https://github.com/hummingbot/hummingbot/pull/1686)
+* Fixed bugs related to input validation of the `import` command !1704
+* Fixed a bug with incorrect display of bot duration in `history` command !1686

--- a/docs/release-notes/0.28.0.md
+++ b/docs/release-notes/0.28.0.md
@@ -33,10 +33,10 @@ When the Hummingbot client makes a trade, it now appends a trade notification me
 
 
 ## 🐞 Other Enhancements and Fixes
-* Added a `minimum_spread` parameter that auto-cancels orders below a certain spread [#1712](https://github.com/hummingbot/hummingbot/issues/1712)
-* Paper trading mode now correctly applies fees charged by the exchange used [#1722](https://github.com/hummingbot/hummingbot/issues/1722)
-* On 0x relayers, Hummingbot now uses `order_refresh_time` to set the order expiration time by default [#1833](https://github.com/hummingbot/hummingbot/issues/1833)
+* Added a `minimum_spread` parameter that auto-cancels orders below a certain spread #1712
+* Paper trading mode now correctly applies fees charged by the exchange used #1722
+* On 0x relayers, Hummingbot now uses `order_refresh_time` to set the order expiration time by default #1833
 * Fixed a bug with BTC pairs on Kraken [#1781](https://github.com/hummingbot/hummingbot/pull/1781)
 * Bamboo Relay maintainer [Arctek](https://github.com/Arctek) fixed bugs with Bamboo Relay that prevented it from working [#1800](https://github.com/hummingbot/hummingbot/pull/1800)
-* Fixed a bug with the `history` command on Kraken [#1780](https://github.com/hummingbot/hummingbot/issues/1780)
-* Fixed a bug in which paper trading mode didn't work with the cross-exchange MM strategy [#1672](https://github.com/hummingbot/hummingbot/issues/1672)
+* Fixed a bug with the `history` command on Kraken #1780
+* Fixed a bug in which paper trading mode didn't work with the cross-exchange MM strategy #1672

--- a/docs/release-notes/0.28.0.md
+++ b/docs/release-notes/0.28.0.md
@@ -36,7 +36,7 @@ When the Hummingbot client makes a trade, it now appends a trade notification me
 * Added a `minimum_spread` parameter that auto-cancels orders below a certain spread #1712
 * Paper trading mode now correctly applies fees charged by the exchange used #1722
 * On 0x relayers, Hummingbot now uses `order_refresh_time` to set the order expiration time by default #1833
-* Fixed a bug with BTC pairs on Kraken [#1781](https://github.com/hummingbot/hummingbot/pull/1781)
-* Bamboo Relay maintainer [Arctek](https://github.com/Arctek) fixed bugs with Bamboo Relay that prevented it from working [#1800](https://github.com/hummingbot/hummingbot/pull/1800)
+* Fixed a bug with BTC pairs on Kraken !1781
+* Bamboo Relay maintainer [Arctek](https://github.com/Arctek) fixed bugs with Bamboo Relay that prevented it from working !1800
 * Fixed a bug with the `history` command on Kraken #1780
 * Fixed a bug in which paper trading mode didn't work with the cross-exchange MM strategy #1672

--- a/docs/release-notes/0.28.1.md
+++ b/docs/release-notes/0.28.1.md
@@ -4,13 +4,13 @@ This release is a hotfix to version [0.28.0](/release-notes/0.28.0).
 
 ## Enhancements
 
-* Added a [fix (#1868)](https://github.com/hummingbot/hummingbot/pull/1868) for an enhancement (#1669) to enter negative values for the `order_level_amount` parameter.
-* Added a [fix (#1869)](https://github.com/hummingbot/hummingbot/pull/1869) for an enhancement (#1752) to set different bid and ask depth for [order optimization](/strategy-configs/order-optimization/).
+* Added a fix (!1868) for an enhancement (#1669) to enter negative values for the `order_level_amount` parameter.
+* Added a fix (!1869) for an enhancement (#1752) to set different bid and ask depth for [order optimization](/strategy-configs/order-optimization/).
 
 ## Bug fixes
 
-* Added a [fix (#1921)](https://github.com/hummingbot/hummingbot/pull/1921) for a Kraken connector bug (#1901) that prevented BTC price updates.
-* Added a [fix (#1932)](https://github.com/hummingbot/hummingbot/pull/1932) for a configuration bug (#1895) that caused a key error in the `celo-arb` strategy when running on Bittrex.
-* Added a [fix (#1892)](https://github.com/hummingbot/hummingbot/pull/1892) for a Docker permissions bug (#1886) that caused errors when updating to the latest version.
-* Added a [fix (#1903)](https://github.com/hummingbot/hummingbot/pull/1903) for a bug (#1902) where orders below minimum order size were submitted, causing trade log exceptions.
-* Added a [fix (#1883)](https://github.com/hummingbot/hummingbot/pull/1883) for a bug (#1677) where available balance on Radar Relay was not updating.
+* Added a fix (!1921) for a Kraken connector bug (#1901) that prevented BTC price updates.
+* Added a fix (!1932) for a configuration bug (#1895) that caused a key error in the `celo-arb` strategy when running on Bittrex.
+* Added a fix (!1892) for a Docker permissions bug (#1886) that caused errors when updating to the latest version.
+* Added a fix (!1903) for a bug (#1902) where orders below minimum order size were submitted, causing trade log exceptions.
+* Added a fix (!1883) for a bug (#1677) where available balance on Radar Relay was not updating.

--- a/docs/release-notes/0.28.1.md
+++ b/docs/release-notes/0.28.1.md
@@ -4,13 +4,13 @@ This release is a hotfix to version [0.28.0](/release-notes/0.28.0).
 
 ## Enhancements
 
-* Added a [fix (#1868)](https://github.com/hummingbot/hummingbot/pull/1868) for an [enhancement (#1669)](https://github.com/hummingbot/hummingbot/issues/1669) to enter negative values for the `order_level_amount` parameter.
-* Added a [fix (#1869)](https://github.com/hummingbot/hummingbot/pull/1869) for an [enhancement (#1752)](https://github.com/hummingbot/hummingbot/issues/1752) to set different bid and ask depth for [order optimization](/strategy-configs/order-optimization/).
+* Added a [fix (#1868)](https://github.com/hummingbot/hummingbot/pull/1868) for an enhancement (#1669) to enter negative values for the `order_level_amount` parameter.
+* Added a [fix (#1869)](https://github.com/hummingbot/hummingbot/pull/1869) for an enhancement (#1752) to set different bid and ask depth for [order optimization](/strategy-configs/order-optimization/).
 
 ## Bug fixes
 
-* Added a [fix (#1921)](https://github.com/hummingbot/hummingbot/pull/1921) for a Kraken connector [bug (#1901)](https://github.com/hummingbot/hummingbot/issues/1901) that prevented BTC price updates.
-* Added a [fix (#1932)](https://github.com/hummingbot/hummingbot/pull/1932) for a configuration [bug (#1895)](https://github.com/hummingbot/hummingbot/issues/1895) that caused a key error in the `celo-arb` strategy when running on Bittrex.
-* Added a [fix (#1892)](https://github.com/hummingbot/hummingbot/pull/1892) for a Docker permissions [bug (#1886)](https://github.com/hummingbot/hummingbot/issues/1886) that caused errors when updating to the latest version.
-* Added a [fix (#1903)](https://github.com/hummingbot/hummingbot/pull/1903) for a [bug (#1902)](https://github.com/hummingbot/hummingbot/issues/1902) where orders below minimum order size were submitted, causing trade log exceptions.
-* Added a [fix (#1883)](https://github.com/hummingbot/hummingbot/pull/1883) for a [bug (#1677)](https://github.com/hummingbot/hummingbot/issues/1677) where available balance on Radar Relay was not updating.
+* Added a [fix (#1921)](https://github.com/hummingbot/hummingbot/pull/1921) for a Kraken connector bug (#1901) that prevented BTC price updates.
+* Added a [fix (#1932)](https://github.com/hummingbot/hummingbot/pull/1932) for a configuration bug (#1895) that caused a key error in the `celo-arb` strategy when running on Bittrex.
+* Added a [fix (#1892)](https://github.com/hummingbot/hummingbot/pull/1892) for a Docker permissions bug (#1886) that caused errors when updating to the latest version.
+* Added a [fix (#1903)](https://github.com/hummingbot/hummingbot/pull/1903) for a bug (#1902) where orders below minimum order size were submitted, causing trade log exceptions.
+* Added a [fix (#1883)](https://github.com/hummingbot/hummingbot/pull/1883) for a bug (#1677) where available balance on Radar Relay was not updating.

--- a/docs/release-notes/0.29.0.md
+++ b/docs/release-notes/0.29.0.md
@@ -35,4 +35,4 @@ In certain cases, this behavior may be desirable even if the fee is higher becau
 * Fixed `_optionals` error when exiting Hummingbot #1946
 * Fixed unhandled trading pair error when running `create` command in Kraken #1959
 * Fixed client and Telegram notification when hanging orders are filled #1974
-* Fixed missing fiat currency pairs in Binance [#1979](https://github.com/hummingbot/hummingbot/pull/1979)
+* Fixed missing fiat currency pairs in Binance !1979

--- a/docs/release-notes/0.29.0.md
+++ b/docs/release-notes/0.29.0.md
@@ -22,17 +22,17 @@ In certain cases, this behavior may be desirable even if the fee is higher becau
 
 ## 🐞 Other Enhancements and Bug Fixes
 
-* Additional debugging message for websocket connection issues [#1426](https://github.com/hummingbot/hummingbot/issues/1426) and when orders get stuck in Bittrex [#1340](https://github.com/hummingbot/hummingbot/issues/1340)
-* Limit orders as LIMIT orders instead of makers and market orders are MARKET instead of takers [#1980](https://github.com/hummingbot/hummingbot/issues/1980)
-* Added cap on base asset range to fix a bug with inventory skew aggressively creating more buy orders even within the target range [#1657](https://github.com/hummingbot/hummingbot/issues/1657)
-* Reduced Infura consumption with websocket connection [#1848](https://github.com/hummingbot/hummingbot/issues/1848)
-* Replaced inventory skew with ping pong feature during basic configuration walkthrough with pure market making strategy [#1970](https://github.com/hummingbot/hummingbot/issues/1970)
+* Additional debugging message for websocket connection issues #1426 and when orders get stuck in Bittrex #1340
+* Limit orders as LIMIT orders instead of makers and market orders are MARKET instead of takers #1980
+* Added cap on base asset range to fix a bug with inventory skew aggressively creating more buy orders even within the target range #1657
+* Reduced Infura consumption with websocket connection #1848
+* Replaced inventory skew with ping pong feature during basic configuration walkthrough with pure market making strategy #1970
 
-* Fixed orders getting stuck in Hummingbot client when trading on Liquid [#1295](https://github.com/hummingbot/hummingbot/issues/1295)
-* Fixed a bug with inventory skew downsizing both buy and sell orders at the same time in a cycle [#1719](https://github.com/hummingbot/hummingbot/issues/1719)
-* Fixed errors when tracking missing orders in web3 wallet class [#1841](https://github.com/hummingbot/hummingbot/issues/1841)
-* Fixed a bug that creates orders using all the remaining balance even when below the specified `order_amount` [#1893](https://github.com/hummingbot/hummingbot/issues/1893)
-* Fixed `_optionals` error when exiting Hummingbot [#1946](https://github.com/hummingbot/hummingbot/issues/1946)
-* Fixed unhandled trading pair error when running `create` command in Kraken [#1959](https://github.com/hummingbot/hummingbot/issues/1959)
-* Fixed client and Telegram notification when hanging orders are filled [#1974](https://github.com/hummingbot/hummingbot/issues/1974)
+* Fixed orders getting stuck in Hummingbot client when trading on Liquid #1295
+* Fixed a bug with inventory skew downsizing both buy and sell orders at the same time in a cycle #1719
+* Fixed errors when tracking missing orders in web3 wallet class #1841
+* Fixed a bug that creates orders using all the remaining balance even when below the specified `order_amount` #1893
+* Fixed `_optionals` error when exiting Hummingbot #1946
+* Fixed unhandled trading pair error when running `create` command in Kraken #1959
+* Fixed client and Telegram notification when hanging orders are filled #1974
 * Fixed missing fiat currency pairs in Binance [#1979](https://github.com/hummingbot/hummingbot/pull/1979)

--- a/docs/release-notes/0.30.0.md
+++ b/docs/release-notes/0.30.0.md
@@ -5,7 +5,7 @@
 
 ## 💵 New command: Balance Limit
 
-As described in feature request [#1443](https://github.com/hummingbot/hummingbot/issues/1443), users can now apply a limit to the total balance to allocate how much the bot can access in an exchange.
+As described in feature request #1443, users can now apply a limit to the total balance to allocate how much the bot can access in an exchange.
 
 This command is useful when running multiple bots sharing the same assets in an account e.g. setting a 50% USDT limit to each bot running BTC-USDT and ETH-USDT pair.
 
@@ -42,7 +42,7 @@ This will also allow running multiple windows of Hummingbot via binary without e
 
 ## 🔧 Other Enhancements
 
-* Ethereum node and websocket can now be configured using the `config` command [#2011](https://github.com/hummingbot/hummingbot/issues/2011)
+* Ethereum node and websocket can now be configured using the `config` command #2011
 * Removed `hang` column from `status` output [#2037](https://github.com/hummingbot/hummingbot/pull/2037)
 * Improved trade fill table in `history` command [#2039](https://github.com/hummingbot/hummingbot/pull/2039)
 * Added validation for script file path when using absolute path [#2035](https://github.com/hummingbot/hummingbot/pull/2035)
@@ -53,23 +53,23 @@ This will also allow running multiple windows of Hummingbot via binary without e
 
 ## 🐞 Bug Fixes
 
-* Removed failing unit test `test_deposit_info` in Liquid [#1574](https://github.com/hummingbot/hummingbot/issues/1574)
-* Fixed duplicate trades bug appearing in `history` output [#1663](https://github.com/hummingbot/hummingbot/issues/1663)
-* Fixed reappeared bug in Kraken where performance calculation in `history` is incorrect [#1671](https://github.com/hummingbot/hummingbot/issues/1671)
-* Fixed reappeared `decimal.DivisionByZero` error in Kraken when running `history` command [#1780](https://github.com/hummingbot/hummingbot/issues/1780)
-* Fixed bug in KuCoin getting stuck when cancelling limit orders [#1804](https://github.com/hummingbot/hummingbot/issues/1804)
-* Fixed failing unit tests `test_limit_maker_rejections` and `test_server_time_offset` in Binance [#1819](https://github.com/hummingbot/hummingbot/issues/1819)
-* Fixed reappeared bug in Kraken where best bid and ask price are not updating [#1901](https://github.com/hummingbot/hummingbot/issues/1901)
-* Fixed `IndexError: list index out of range` when using order optimization with ping pong and price band [#1944](https://github.com/hummingbot/hummingbot/issues/1944)
+* Removed failing unit test `test_deposit_info` in Liquid #1574
+* Fixed duplicate trades bug appearing in `history` output #1663
+* Fixed reappeared bug in Kraken where performance calculation in `history` is incorrect #1671
+* Fixed reappeared `decimal.DivisionByZero` error in Kraken when running `history` command #1780
+* Fixed bug in KuCoin getting stuck when cancelling limit orders #1804
+* Fixed failing unit tests `test_limit_maker_rejections` and `test_server_time_offset` in Binance #1819
+* Fixed reappeared bug in Kraken where best bid and ask price are not updating #1901
+* Fixed `IndexError: list index out of range` when using order optimization with ping pong and price band #1944
 * Fixed how balances are shown per exchange in an easy to read format [#2041](https://github.com/hummingbot/hummingbot/pull/2041)
-* Fixed high CPU usage when running on decentralized exchange connectors [#2049](https://github.com/hummingbot/hummingbot/issues/2049)
+* Fixed high CPU usage when running on decentralized exchange connectors #2049
 
 ## Developers Updates 
 
-* Deprecated Market order type in centralized exchange connectors [#1911](https://github.com/hummingbot/hummingbot/issues/1911)
-* Added `LIMIT_MAKER` order type to all applicable market connectors [#1912](https://github.com/hummingbot/hummingbot/issues/1912)
-* Added `last_trade_price` in market connectors [#2036](https://github.com/hummingbot/hummingbot/issues/2036)
-* Removed deposit and withdrawal functionality from all connectors [#2061](https://github.com/hummingbot/hummingbot/issues/2061)
+* Deprecated Market order type in centralized exchange connectors #1911
+* Added `LIMIT_MAKER` order type to all applicable market connectors #1912
+* Added `last_trade_price` in market connectors #2036
+* Removed deposit and withdrawal functionality from all connectors #2061
 
 ## Connector Change Summary
 

--- a/docs/release-notes/0.30.0.md
+++ b/docs/release-notes/0.30.0.md
@@ -43,12 +43,12 @@ This will also allow running multiple windows of Hummingbot via binary without e
 ## 🔧 Other Enhancements
 
 * Ethereum node and websocket can now be configured using the `config` command #2011
-* Removed `hang` column from `status` output [#2037](https://github.com/hummingbot/hummingbot/pull/2037)
-* Improved trade fill table in `history` command [#2039](https://github.com/hummingbot/hummingbot/pull/2039)
-* Added validation for script file path when using absolute path [#2035](https://github.com/hummingbot/hummingbot/pull/2035)
-* Passwords created the first time are now saved [#2066](https://github.com/hummingbot/hummingbot/pull/2066)
-* Completely removed Bitcoin.com connector from codebase [#2095](https://github.com/hummingbot/hummingbot/pull/2095)
-* Implemented Huobi websocket API as part of maintaining user account balances in market connectors [#2140](https://github.com/hummingbot/hummingbot/pull/2140)
+* Removed `hang` column from `status` output !2037
+* Improved trade fill table in `history` command !2039
+* Added validation for script file path when using absolute path !2035
+* Passwords created the first time are now saved !2066
+* Completely removed Bitcoin.com connector from codebase !2095
+* Implemented Huobi websocket API as part of maintaining user account balances in market connectors !2140
 
 
 ## 🐞 Bug Fixes
@@ -61,7 +61,7 @@ This will also allow running multiple windows of Hummingbot via binary without e
 * Fixed failing unit tests `test_limit_maker_rejections` and `test_server_time_offset` in Binance #1819
 * Fixed reappeared bug in Kraken where best bid and ask price are not updating #1901
 * Fixed `IndexError: list index out of range` when using order optimization with ping pong and price band #1944
-* Fixed how balances are shown per exchange in an easy to read format [#2041](https://github.com/hummingbot/hummingbot/pull/2041)
+* Fixed how balances are shown per exchange in an easy to read format !2041
 * Fixed high CPU usage when running on decentralized exchange connectors #2049
 
 ## Developers Updates 

--- a/docs/release-notes/0.31.0.md
+++ b/docs/release-notes/0.31.0.md
@@ -33,13 +33,13 @@ More information in our documentation in [External Pricing Source Configuration]
 
 In the ongoing effort to make the Hummingbot code base more developer friendly, we refactored several parts of the exchange connector code to make it easier to add additional exchanges in the future:
 
-* Added a new `ExchangeBase` class to replace `MarketBase` #2243, [#2250](https://github.com/hummingbot/hummingbot/pull/2250)
-* Removed `OrderBookTrackerDataSourceType` and `UserStreamTrackerDataSourceType` from connector #2244, [#2270](https://github.com/hummingbot/hummingbot/pull/2270)
-* Moved exchange connectors to a new location: [hummingbot/connector/exchange](https://github.com/hummingbot/hummingbot/tree/development/hummingbot/connector/exchange)</br>#2244, [#2270](https://github.com/hummingbot/hummingbot/pull/2270)
+* Added a new `ExchangeBase` class to replace `MarketBase` #2243, !2250
+* Removed `OrderBookTrackerDataSourceType` and `UserStreamTrackerDataSourceType` from connector #2244, !2270
+* Moved exchange connectors to a new location: [hummingbot/connector/exchange](https://github.com/hummingbot/hummingbot/tree/development/hummingbot/connector/exchange)</br>#2244, !2270
 * Added `_real_time_balance_update` to `ExchangeBase`, set this to `True` if your connector doesn't provide account balance 
 update via web socket API, you will also need to set `_in_flight_orders_snapshot` and `_in_flight_orders_snapshot_timestamp` 
-during balance update #2017, [#2224](https://github.com/hummingbot/hummingbot/pull/2224)
-* Formalize trading pair format, except within the connector module, all trading pairs are in BASE-QUOTE format #2091, [#2097](https://github.com/hummingbot/hummingbot/pull/2097)
+during balance update #2017, !2224
+* Formalize trading pair format, except within the connector module, all trading pairs are in BASE-QUOTE format #2091, !2097
 * Remove market argument on `InFlightOrderBase` (it was never used for anything)
 
 

--- a/docs/release-notes/0.31.0.md
+++ b/docs/release-notes/0.31.0.md
@@ -33,21 +33,21 @@ More information in our documentation in [External Pricing Source Configuration]
 
 In the ongoing effort to make the Hummingbot code base more developer friendly, we refactored several parts of the exchange connector code to make it easier to add additional exchanges in the future:
 
-* Added a new `ExchangeBase` class to replace `MarketBase` [#2243](https://github.com/hummingbot/hummingbot/issues/2243), [#2250](https://github.com/hummingbot/hummingbot/pull/2250)
-* Removed `OrderBookTrackerDataSourceType` and `UserStreamTrackerDataSourceType` from connector [#2244](https://github.com/hummingbot/hummingbot/issues/2244), [#2270](https://github.com/hummingbot/hummingbot/pull/2270)
-* Moved exchange connectors to a new location: [hummingbot/connector/exchange](https://github.com/hummingbot/hummingbot/tree/development/hummingbot/connector/exchange)</br>[#2244](https://github.com/hummingbot/hummingbot/issues/2244), [#2270](https://github.com/hummingbot/hummingbot/pull/2270)
+* Added a new `ExchangeBase` class to replace `MarketBase` #2243, [#2250](https://github.com/hummingbot/hummingbot/pull/2250)
+* Removed `OrderBookTrackerDataSourceType` and `UserStreamTrackerDataSourceType` from connector #2244, [#2270](https://github.com/hummingbot/hummingbot/pull/2270)
+* Moved exchange connectors to a new location: [hummingbot/connector/exchange](https://github.com/hummingbot/hummingbot/tree/development/hummingbot/connector/exchange)</br>#2244, [#2270](https://github.com/hummingbot/hummingbot/pull/2270)
 * Added `_real_time_balance_update` to `ExchangeBase`, set this to `True` if your connector doesn't provide account balance 
 update via web socket API, you will also need to set `_in_flight_orders_snapshot` and `_in_flight_orders_snapshot_timestamp` 
-during balance update [#2017](https://github.com/hummingbot/hummingbot/issues/2017), [#2224](https://github.com/hummingbot/hummingbot/pull/2224)
-* Formalize trading pair format, except within the connector module, all trading pairs are in BASE-QUOTE format [#2091](https://github.com/hummingbot/hummingbot/issues/2091), [#2097](https://github.com/hummingbot/hummingbot/pull/2097)
+during balance update #2017, [#2224](https://github.com/hummingbot/hummingbot/pull/2224)
+* Formalize trading pair format, except within the connector module, all trading pairs are in BASE-QUOTE format #2091, [#2097](https://github.com/hummingbot/hummingbot/pull/2097)
 * Remove market argument on `InFlightOrderBase` (it was never used for anything)
 
 
 ## 🐞 Bug Fixes
 
-* Fixed `OrderBookTracker` trade execution bug [#1330](https://github.com/hummingbot/hummingbot/issues/1330)
-* Fixed bug where some orders are not created due to broken account balance update [#2012](https://github.com/hummingbot/hummingbot/issues/2012)
-* Fixed inconsistent adjusted order amount with inventory skew [#2058](https://github.com/hummingbot/hummingbot/issues/2058)
-* Fixed API requests intermittently failing on Kraken connector [#2204](https://github.com/hummingbot/hummingbot/issues/2204) </br> **We want to thank 🙏 community member [TheHolyRoger](https://github.com/TheHolyRoger) for this contribution!**
-* Fixed bug with Liquid connector incorrectly integrating web socket for user data stream [#2222](https://github.com/hummingbot/hummingbot/issues/2222)
-* Added DAI to trading pair splitter to address an issue where DAI trading pairs are not showing in Binance connector [#2255](https://github.com/hummingbot/hummingbot/issues/2255)
+* Fixed `OrderBookTracker` trade execution bug #1330
+* Fixed bug where some orders are not created due to broken account balance update #2012
+* Fixed inconsistent adjusted order amount with inventory skew #2058
+* Fixed API requests intermittently failing on Kraken connector #2204 </br> **We want to thank 🙏 community member [TheHolyRoger](https://github.com/TheHolyRoger) for this contribution!**
+* Fixed bug with Liquid connector incorrectly integrating web socket for user data stream #2222
+* Added DAI to trading pair splitter to address an issue where DAI trading pairs are not showing in Binance connector #2255

--- a/docs/release-notes/0.32.0.md
+++ b/docs/release-notes/0.32.0.md
@@ -69,7 +69,7 @@ In the ongoing effort to make the Hummingbot code base more developer friendly, 
 ## 🔧 Other Enhancements
 
 * In arbitrage strategy, the `status` command displays last calculated profitability #2151
-* The `status` command displays the price reference used when creating orders [#2332](https://github.com/hummingbot/hummingbot/pull/2332)
+* The `status` command displays the price reference used when creating orders !2332
 
 
 ## 🐞 Bug Fixes

--- a/docs/release-notes/0.32.0.md
+++ b/docs/release-notes/0.32.0.md
@@ -68,13 +68,13 @@ In the ongoing effort to make the Hummingbot code base more developer friendly, 
 
 ## 🔧 Other Enhancements
 
-* In arbitrage strategy, the `status` command displays last calculated profitability [#2151](https://github.com/hummingbot/hummingbot/issues/2151)
+* In arbitrage strategy, the `status` command displays last calculated profitability #2151
 * The `status` command displays the price reference used when creating orders [#2332](https://github.com/hummingbot/hummingbot/pull/2332)
 
 
 ## 🐞 Bug Fixes
 
-* Cross exchange strategy not executing taker orders due to illegal characters [#2226](https://github.com/hummingbot/hummingbot/issues/2226)
-* Celo balance update error when celocli new version is available [#2319](https://github.com/hummingbot/hummingbot/issues/2319)
-* Fail to submit orders in cross exchange due to HTTP status 400 "BAD_REQUEST" [#2326](https://github.com/hummingbot/hummingbot/issues/2326)
-* Kucoin connector takes a while to get ready [#2348](https://github.com/hummingbot/hummingbot/issues/2348)
+* Cross exchange strategy not executing taker orders due to illegal characters #2226
+* Celo balance update error when celocli new version is available #2319
+* Fail to submit orders in cross exchange due to HTTP status 400 "BAD_REQUEST" #2326
+* Kucoin connector takes a while to get ready #2348

--- a/docs/release-notes/0.33.0.md
+++ b/docs/release-notes/0.33.0.md
@@ -10,7 +10,7 @@ We are excited to release not one but two strategy:
 
 ## 📊 New argument [--live]
 
-[#2519](https://github.com/hummingbot/hummingbot/pull/2519): This new argument displays live updates for the following commands:
+!2519: This new argument displays live updates for the following commands:
 
 - ticker, see sample usage in our [documentation](https://docs.hummingbot.io/operation/status/#view-market-ticker-prices)
 - orderbook, see sample usage in our [documentation](https://docs.hummingbot.io/operation/status/#view-market-order-book)
@@ -22,7 +22,7 @@ The following connectors are now supported:
 
 - #1518, [Binance.us](https://www.binance.us) was launched in September 2019, Binance.US is a digital asset marketplace, powered by matching engine and wallet technologies licensed from the world’s largest cryptocurrency exchange, Binance. Operated by BAM Trading Services based in San Francisco, California, Binance.US provides a fast, secure and reliable platform to buy and sell cryptocurrencies in the United States.
 - #2246, [Binance Futures](https://www.binance.com/en/futures) currently offers the highest leverage of 125x margin among major crypto exchanges, making it one of the most competitive products in the market. **Note:** Binance Perpetual connector is released as a beta version(0.33), trade it at your own risk.
-- [#2262](https://github.com/hummingbot/hummingbot/pull/2262), [OKEX](https://www.okex.com/) is a world-leading cryptocurrency exchange, providing advanced financial services to traders globally by using blockchain technology.
+- !2262, [OKEX](https://www.okex.com/) is a world-leading cryptocurrency exchange, providing advanced financial services to traders globally by using blockchain technology.
 - #2358,#2474, [Balancer](https://balancer.finance/) is an automated portfolio manager, liquidity provider, and price sensor.
 
 ## 🔄 UI/UX Enhancements
@@ -37,7 +37,7 @@ The following connectors are now supported:
 
 - #2452: Update Docker helper scripts
 - #2482: Unify connector settings loading process.
-- [#2522](https://github.com/hummingbot/hummingbot/pull/2522): Loopring connector refactoring and fixes.
+- !2522: Loopring connector refactoring and fixes.
 
 ### 📁 Database
 

--- a/docs/release-notes/0.33.0.md
+++ b/docs/release-notes/0.33.0.md
@@ -20,42 +20,42 @@ We are excited to release not one but two strategy:
 
 The following connectors are now supported:
 
-- [#1518](https://github.com/hummingbot/hummingbot/issues/1518), [Binance.us](https://www.binance.us) was launched in September 2019, Binance.US is a digital asset marketplace, powered by matching engine and wallet technologies licensed from the world’s largest cryptocurrency exchange, Binance. Operated by BAM Trading Services based in San Francisco, California, Binance.US provides a fast, secure and reliable platform to buy and sell cryptocurrencies in the United States.
-- [#2246](https://github.com/hummingbot/hummingbot/issues/2246), [Binance Futures](https://www.binance.com/en/futures) currently offers the highest leverage of 125x margin among major crypto exchanges, making it one of the most competitive products in the market. **Note:** Binance Perpetual connector is released as a beta version(0.33), trade it at your own risk.
+- #1518, [Binance.us](https://www.binance.us) was launched in September 2019, Binance.US is a digital asset marketplace, powered by matching engine and wallet technologies licensed from the world’s largest cryptocurrency exchange, Binance. Operated by BAM Trading Services based in San Francisco, California, Binance.US provides a fast, secure and reliable platform to buy and sell cryptocurrencies in the United States.
+- #2246, [Binance Futures](https://www.binance.com/en/futures) currently offers the highest leverage of 125x margin among major crypto exchanges, making it one of the most competitive products in the market. **Note:** Binance Perpetual connector is released as a beta version(0.33), trade it at your own risk.
 - [#2262](https://github.com/hummingbot/hummingbot/pull/2262), [OKEX](https://www.okex.com/) is a world-leading cryptocurrency exchange, providing advanced financial services to traders globally by using blockchain technology.
-- [#2358](https://github.com/hummingbot/hummingbot/issues/2358),[#2474](https://github.com/hummingbot/hummingbot/issues/2474), [Balancer](https://balancer.finance/) is an automated portfolio manager, liquidity provider, and price sensor.
+- #2358,#2474, [Balancer](https://balancer.finance/) is an automated portfolio manager, liquidity provider, and price sensor.
 
 ## 🔄 UI/UX Enhancements
 
-- [#2430](https://github.com/hummingbot/hummingbot/issues/2430): Additional connector status column display when using `connect` command. Also, you can view the connector status in the [readme](https://github.com/hummingbot/hummingbot/blob/master/README.md) file.
-- [#2179](https://github.com/hummingbot/hummingbot/issues/2179): The Hummingbot client top and bottom navbars are enhanced with usage information, see [User Interface](/operation/user-interface/) for details.
-- [#2129](https://github.com/hummingbot/hummingbot/issues/2129): The `history` command is redesigned with more information and additional arguments, see [History](https://docs.hummingbot.io/operation/history/#history-command) for details.
+- #2430: Additional connector status column display when using `connect` command. Also, you can view the connector status in the [readme](https://github.com/hummingbot/hummingbot/blob/master/README.md) file.
+- #2179: The Hummingbot client top and bottom navbars are enhanced with usage information, see [User Interface](/operation/user-interface/) for details.
+- #2129: The `history` command is redesigned with more information and additional arguments, see [History](https://docs.hummingbot.io/operation/history/#history-command) for details.
 
 ## 💻 Developers Updates
 
 ### Refactoring
 
-- [#2452](https://github.com/hummingbot/hummingbot/issues/2452): Update Docker helper scripts
-- [#2482](https://github.com/hummingbot/hummingbot/issues/2482): Unify connector settings loading process.
+- #2452: Update Docker helper scripts
+- #2482: Unify connector settings loading process.
 - [#2522](https://github.com/hummingbot/hummingbot/pull/2522): Loopring connector refactoring and fixes.
 
 ### 📁 Database
 
-[#2106](https://github.com/hummingbot/hummingbot/issues/2106): Create new SQLite db files for individual strategies.
+#2106: Create new SQLite db files for individual strategies.
 
 ### 🔧 Scripts
 
-- [#2411](https://github.com/hummingbot/hummingbot/issues/2411): A new script template is added to help developers get started quickly.
-- [#2492](https://github.com/hummingbot/hummingbot/issues/2492): The following data and settings are now available in scripts.
+- #2411: A new script template is added to help developers get started quickly.
+- #2492: The following data and settings are now available in scripts.
   - Exchange and trading pair settings one time off (read-only)
   - User available balances
   - Inventory skew and order override settings
 
 ## 🐞 Bug Fixes
 
-- [#2321](https://github.com/hummingbot/hummingbot/issues/2321): Hummingbot to place an order size of the remaining available balance if the balance is less than the order_amount.
-- [#2249](https://github.com/hummingbot/hummingbot/issues/2249): Setup fails on a clean install of Ubuntu.
-- [#2444](https://github.com/hummingbot/hummingbot/issues/2444): Unable to connect to any exchange using Hummingbot binary on Mac.
+- #2321: Hummingbot to place an order size of the remaining available balance if the balance is less than the order_amount.
+- #2249: Setup fails on a clean install of Ubuntu.
+- #2444: Unable to connect to any exchange using Hummingbot binary on Mac.
 
 ## 📜 Improved Doc Site
 

--- a/docs/release-notes/0.33.1.md
+++ b/docs/release-notes/0.33.1.md
@@ -2,4 +2,4 @@
 
 This release is a hotfix to version [0.33.0](/release-notes/0.33.0).
 
-It contains [#2661](https://github.com/hummingbot/hummingbot/pull/2661) to fix the bug when trying to set up or run specific BUSD pairs on Binance as described in GitHub issue [#2653](https://github.com/hummingbot/hummingbot/issues/2653).
+It contains [#2661](https://github.com/hummingbot/hummingbot/pull/2661) to fix the bug when trying to set up or run specific BUSD pairs on Binance as described in GitHub issue #2653.

--- a/docs/release-notes/0.33.1.md
+++ b/docs/release-notes/0.33.1.md
@@ -2,4 +2,4 @@
 
 This release is a hotfix to version [0.33.0](/release-notes/0.33.0).
 
-It contains [#2661](https://github.com/hummingbot/hummingbot/pull/2661) to fix the bug when trying to set up or run specific BUSD pairs on Binance as described in GitHub issue #2653.
+It contains !2661 to fix the bug when trying to set up or run specific BUSD pairs on Binance as described in GitHub issue #2653.

--- a/docs/release-notes/0.34.0.md
+++ b/docs/release-notes/0.34.0.md
@@ -33,9 +33,9 @@ Read more in our documentation how to use the connector [here](/protocols/terra/
 
 In this release, we have made substantial improvements to the `amm-arb` strategy that can be used to arbitrage between AMM protocols and order book exchanges:
 
-- [#2672](https://github.com/hummingbot/hummingbot/issues/2672): Dynamically calculate gas price into Balancer
-- [#2734](https://github.com/hummingbot/hummingbot/issues/2734): Correctly add gas cost to Ethereum transactions
-- [#2694](https://github.com/hummingbot/hummingbot/issues/2694): Poll for Ethereum transactions from Hummingbot
+- #2672: Dynamically calculate gas price into Balancer
+- #2734: Correctly add gas cost to Ethereum transactions
+- #2694: Poll for Ethereum transactions from Hummingbot
 
 We have also simplified the installation script for the Gateway module to pull specific values from the user's Hummingbot installation automatically.
 
@@ -78,8 +78,8 @@ Learn more: https://hummingbot.io/blog/2020-12-aggregate-trade-data-collection-n
 
 ## Bug Fixes
 
-- [#2318](https://github.com/hummingbot/hummingbot/issues/2318): Websocket connection issues on Crypto.com connector
-- [#2472](https://github.com/hummingbot/hummingbot/issues/2472): Bot keeps looping on canceling orders on Crypto.com connector
-- [#2539](https://github.com/hummingbot/hummingbot/issues/2539): Kraken: Unexpected error in user stream listener loop
-- [#2569](https://github.com/hummingbot/hummingbot/issues/2569): Bot unable to display both open positions
-- [#2573](https://github.com/hummingbot/hummingbot/issues/2573): binance_perpetual_testnet price_source external_market does not seem to work
+- #2318: Websocket connection issues on Crypto.com connector
+- #2472: Bot keeps looping on canceling orders on Crypto.com connector
+- #2539: Kraken: Unexpected error in user stream listener loop
+- #2569: Bot unable to display both open positions
+- #2573: binance_perpetual_testnet price_source external_market does not seem to work

--- a/docs/release-notes/0.35.0.md
+++ b/docs/release-notes/0.35.0.md
@@ -34,11 +34,11 @@ In v0.35.0, we have made the following improvements:
 - [Gateway #33](https://github.com/CoinAlpha/gateway-api/pull/33): Added dynamic routes to the Uniswap connector to find optimal trade execution prices
 - [Gateway #32](https://github.com/CoinAlpha/gateway-api/pull/32): Added logging to Gateway to improve testing
 - [#2784](https://github.com/hummingbot/hummingbot/pull/2784): Fixed a display issue with the `history` command when running the `amm-arb` strategy
-- [#2772](https://github.com/hummingbot/hummingbot/issues/2772): Simplified parameter structure for Hummingbot-Gateway communications, which makes testing ETH connectors easier
+- #2772: Simplified parameter structure for Hummingbot-Gateway communications, which makes testing ETH connectors easier
 
 ## Remove default `start` command
 
-In [#2496](https://github.com/hummingbot/hummingbot/issues/2496), Hummingbot no longer auto-fills the `start` command after the user has created or imported a strategy,
+In #2496, Hummingbot no longer auto-fills the `start` command after the user has created or imported a strategy,
 
 ## Disable balance limit from client
 

--- a/docs/release-notes/0.35.0.md
+++ b/docs/release-notes/0.35.0.md
@@ -21,7 +21,7 @@ v0.34.0 added a feature that allows you to tell the bot how to manage open posit
 
 We've also made some smaller enhancements and bug fixes to this strategy in v0.35:
 
-- [#2786](https://github.com/hummingbot/hummingbot/pull/2786): Fixed an issue in which the bot displayed a trading pair-rule error when starting on testnet
+- !2786: Fixed an issue in which the bot displayed a trading pair-rule error when starting on testnet
 
 ## Usability improvements for protocol connectors
 
@@ -33,7 +33,7 @@ In v0.35.0, we have made the following improvements:
 
 - [Gateway #33](https://github.com/CoinAlpha/gateway-api/pull/33): Added dynamic routes to the Uniswap connector to find optimal trade execution prices
 - [Gateway #32](https://github.com/CoinAlpha/gateway-api/pull/32): Added logging to Gateway to improve testing
-- [#2784](https://github.com/hummingbot/hummingbot/pull/2784): Fixed a display issue with the `history` command when running the `amm-arb` strategy
+- !2784: Fixed a display issue with the `history` command when running the `amm-arb` strategy
 - #2772: Simplified parameter structure for Hummingbot-Gateway communications, which makes testing ETH connectors easier
 
 ## Remove default `start` command
@@ -58,13 +58,13 @@ When there are multiple tokens used to pay fees, Hummingbot now displays a list 
 
 ## ETH rate conversion
 
-In [#2811](https://github.com/hummingbot/hummingbot/pull/2811), a message will appear on the logs after starting your `amm_arb` strategy that shows you an estimated conversion rate of ETH. It only shows when you are trading in non WETH markets.
+In !2811, a message will appear on the logs after starting your `amm_arb` strategy that shows you an estimated conversion rate of ETH. It only shows when you are trading in non WETH markets.
 
 ![](/assets/img/ethereum-conversion.png)
 
 ## Bug Fixes
 
-- [#2801](https://github.com/hummingbot/hummingbot/pull/2801): Fixed a bug in which trading pairs with AUD as the quote asset were not showing up in the auto-complete helper
-- [#2788](https://github.com/hummingbot/hummingbot/pull/2788): Remove update balance log
-- [#2758](https://github.com/hummingbot/hummingbot/pull/2758): Add decimals to balancer connector request to Gateway. Balancer is modified to handle decimals properly. This should avoid errors when running the `balance` command.
-- [#2799](https://github.com/hummingbot/hummingbot/pull/2799): `paper_trade` on cross exchange market making now correctly displays the maker and taker exchange when running the `status` command.
+- !2801: Fixed a bug in which trading pairs with AUD as the quote asset were not showing up in the auto-complete helper
+- !2788: Remove update balance log
+- !2758: Add decimals to balancer connector request to Gateway. Balancer is modified to handle decimals properly. This should avoid errors when running the `balance` command.
+- !2799: `paper_trade` on cross exchange market making now correctly displays the maker and taker exchange when running the `status` command.

--- a/docs/release-notes/0.36.0.md
+++ b/docs/release-notes/0.36.0.md
@@ -27,7 +27,7 @@ Read more about how to use the Blocktane connector [here](/exchanges/blocktane/)
 
 ## Loopring connector updated to v3 API in Hummingbot client
 
-In the previous version, Hummingbot used Loopring's v1 API, which has since been deprecated. With this update, Hummingbot will be using [Loopring's v3 API](https://docs.loopring.io/en/). With the updated Loopring connector in this version, any existing API keys used previously in Loopring v1 API will be invalid. Users must generate new keys from the latest version of the exchange. Learn more about the change here [#2885](https://github.com/hummingbot/hummingbot/pull/2885).
+In the previous version, Hummingbot used Loopring's v1 API, which has since been deprecated. With this update, Hummingbot will be using [Loopring's v3 API](https://docs.loopring.io/en/). With the updated Loopring connector in this version, any existing API keys used previously in Loopring v1 API will be invalid. Users must generate new keys from the latest version of the exchange. Learn more about the change here !2885.
 
 Refer to the documentation [here](/exchanges/loopring/), to update your API keys.
 
@@ -35,15 +35,15 @@ Refer to the documentation [here](/exchanges/loopring/), to update your API keys
 
 In v0.36, we introduce the new Liquidity Mining strategy! This strategy helps users who want to participate in Liquidity Mining. This simple strategy enables users to quickly set up a liquidity mining bot with just a few configuration parameters.
 
-This strategy also allows users to make markets in more than one market pair on the specified exchange, boosting their liquidity mining rewards! We are planning to add more configurable parameters for more advanced users to customize the strategy further. Learn more about it here [#2871](https://github.com/hummingbot/hummingbot/pull/2871).
+This strategy also allows users to make markets in more than one market pair on the specified exchange, boosting their liquidity mining rewards! We are planning to add more configurable parameters for more advanced users to customize the strategy further. Learn more about it here !2871.
 
 ![](/assets/img/liquidity-mining-strategy.png)
 
 ## `Perpetual_market_making` improvement
 
-In v0.36, we added a new feature to the perpetual market-making strategy. `stop_loss_spread` is now available with the `Profit_taking` and `Trailing_stop` features. Learn more about it here [#2880](https://github.com/hummingbot/hummingbot/pull/2880).
+In v0.36, we added a new feature to the perpetual market-making strategy. `stop_loss_spread` is now available with the `Profit_taking` and `Trailing_stop` features. Learn more about it here !2880.
 
-Hummingbot does not show the correct calculation of PnL and return % when initiating the `history` command in the previous version. A fix and enhancement were done to show the accurate calculation and output on `total PnL` and `return %` when using the `history` command. You can learn more here [#2855](https://github.com/hummingbot/hummingbot/pull/2855).
+Hummingbot does not show the correct calculation of PnL and return % when initiating the `history` command in the previous version. A fix and enhancement were done to show the accurate calculation and output on `total PnL` and `return %` when using the `history` command. You can learn more here !2855.
 
 ![](/assets/img/history-pnl.png)
 
@@ -52,7 +52,7 @@ Hummingbot does not show the correct calculation of PnL and return % when initia
 
 ## Inventory average cost added as a new price_type configuration
 
-With this new `price_type`, Hummingbot will calculate the average cost of your inventory every time a buy order is filled, and all sell orders will be created at `inventory_cost` + `ask_spread`. Learn more here [#2513](https://github.com/hummingbot/hummingbot/pull/2513).
+With this new `price_type`, Hummingbot will calculate the average cost of your inventory every time a buy order is filled, and all sell orders will be created at `inventory_cost` + `ask_spread`. Learn more here !2513.
 
 ![](/assets/img/inventory-price-type.png)
 
@@ -63,17 +63,17 @@ We made some improvements to address network connectivity issues that result in 
 - Pick up trade from API and will trigger OrderFilled if missing in local history.
 - Will prevent the filing of duplicated orders.
 
-Added improvements on the interaction between connector and TradeFills table in order to check for existing orders. For more information, see here [#2793](https://github.com/hummingbot/hummingbot/pull/2793).
+Added improvements on the interaction between connector and TradeFills table in order to check for existing orders. For more information, see here !2793.
 
 ## Bug Fixes
 
-- [#2829](https://github.com/hummingbot/hummingbot/pull/2829): Fix the 10-second delay when creating orders in the Huobi exchange
-- [#2857](https://github.com/hummingbot/hummingbot/pull/2857): Addresses the problem regarding connectivity issues with Cloudflare. Fix API requests intermittently failing on Kraken.
-- [#2876](https://github.com/hummingbot/hummingbot/pull/2876): Fix incorrect balance reporting when running `balance` command on Binance and Bitfinex exchanges
-- [#2906](https://github.com/hummingbot/hummingbot/pull/2906): Fix missing trading pairs in Bitfinex and added USD missing value
-- [#2907](https://github.com/hummingbot/hummingbot/pull/2907): Fix circular dependencies resulting in unexpected errors in unit tests
-- [#2910](https://github.com/hummingbot/hummingbot/pull/2910): Fixes bugs pertaining to `in_flight_order` reconciliation and retrieving trade history
-- [#2911](https://github.com/hummingbot/hummingbot/pull/2911): Fix issue about paper trading orders canceling in a loop
-- [#2915](https://github.com/hummingbot/hummingbot/pull/2915): Included exponential waiting time between each Kraken API request retry interval
-- [#2853](https://github.com/hummingbot/hummingbot/pull/2853): Include additional strategy file checks before collating trade data.
-- [#2931](https://github.com/hummingbot/hummingbot/pull/2931): Fix error when `pnl` command is run. Update `pnl` command to check for markets config setting; this is so that it can work with the new Liquidity Mining strategy.
+- !2829: Fix the 10-second delay when creating orders in the Huobi exchange
+- !2857: Addresses the problem regarding connectivity issues with Cloudflare. Fix API requests intermittently failing on Kraken.
+- !2876: Fix incorrect balance reporting when running `balance` command on Binance and Bitfinex exchanges
+- !2906: Fix missing trading pairs in Bitfinex and added USD missing value
+- !2907: Fix circular dependencies resulting in unexpected errors in unit tests
+- !2910: Fixes bugs pertaining to `in_flight_order` reconciliation and retrieving trade history
+- !2911: Fix issue about paper trading orders canceling in a loop
+- !2915: Included exponential waiting time between each Kraken API request retry interval
+- !2853: Include additional strategy file checks before collating trade data.
+- !2931: Fix error when `pnl` command is run. Update `pnl` command to check for markets config setting; this is so that it can work with the new Liquidity Mining strategy.

--- a/docs/release-notes/0.37.0.md
+++ b/docs/release-notes/0.37.0.md
@@ -53,7 +53,7 @@ Learn more about the changes to the [Liquidity Mining Strategy](/strategies/liqu
   - **We want to thank community member [Iamtha](https://github.com/lamtha) for this contribution!**
 - [#2959](https://github.com/hummingbot/hummingbot/pull/2959) Pause and Resume fixed for Liquidity Mining strategy
 - [#2959](https://github.com/hummingbot/hummingbot/pull/2979) Remove Telegram formatting tags
-- [#2987](https://github.com/hummingbot/hummingbot/pull/2987) Adds better parsing of Kraken trading symbols and fixes bugs [#1781](https://github.com/hummingbot/hummingbot/issues/1781), [#2930](https://github.com/hummingbot/hummingbot/issues/2930), and [#2953](https://github.com/hummingbot/hummingbot/issues/2953)
+- [#2987](https://github.com/hummingbot/hummingbot/pull/2987) Adds better parsing of Kraken trading symbols and fixes bugs #1781, #2930, and #2953
 - [#2989](https://github.com/hummingbot/hummingbot/pull/2989) Fix typo in `history` command
   - **We want to thank community member [krisklosterman](https://github.com/krisklosterman) for this contribution!**
 - [#2997](https://github.com/hummingbot/hummingbot/pull/2997) Added VAI trading pair

--- a/docs/release-notes/0.37.0.md
+++ b/docs/release-notes/0.37.0.md
@@ -49,18 +49,18 @@ Learn more about the changes to the [Liquidity Mining Strategy](/strategies/liqu
 
 ## Bug Fixes
 
-- [#2949](https://github.com/hummingbot/hummingbot/pull/2949) Add `Exchanges Total` to `balance` command
+- !2949 Add `Exchanges Total` to `balance` command
   - **We want to thank community member [Iamtha](https://github.com/lamtha) for this contribution!**
-- [#2959](https://github.com/hummingbot/hummingbot/pull/2959) Pause and Resume fixed for Liquidity Mining strategy
+- !2959 Pause and Resume fixed for Liquidity Mining strategy
 - [#2959](https://github.com/hummingbot/hummingbot/pull/2979) Remove Telegram formatting tags
-- [#2987](https://github.com/hummingbot/hummingbot/pull/2987) Adds better parsing of Kraken trading symbols and fixes bugs #1781, #2930, and #2953
-- [#2989](https://github.com/hummingbot/hummingbot/pull/2989) Fix typo in `history` command
+- !2987 Adds better parsing of Kraken trading symbols and fixes bugs #1781, #2930, and #2953
+- !2989 Fix typo in `history` command
   - **We want to thank community member [krisklosterman](https://github.com/krisklosterman) for this contribution!**
-- [#2997](https://github.com/hummingbot/hummingbot/pull/2997) Added VAI trading pair
-- [#2999](https://github.com/hummingbot/hummingbot/pull/2999) Fix orders canceling in a loop in Cross Exchange Market Making when using `paper_trade`
-- [#3000](https://github.com/hummingbot/hummingbot/pull/3000) Fix orders canceling in a loop when the balance is too low when using `paper_trade`
+- !2997 Added VAI trading pair
+- !2999 Fix orders canceling in a loop in Cross Exchange Market Making when using `paper_trade`
+- !3000 Fix orders canceling in a loop when the balance is too low when using `paper_trade`
   - **We want to thank community member [TheHolyRoger](https://github.com/TheHolyRoger) for these contributions!**
-- [#3002](https://github.com/hummingbot/hummingbot/pull/3002) Fix invalid orders that are being tracked by the bot
-- [#3005](https://github.com/hummingbot/hummingbot/pull/3005) Fix market validators for `amm_arb strategy`
-- [#3014](https://github.com/hummingbot/hummingbot/pull/3014) Fix Kraken available balance after running the status command
-- [#3046](https://github.com/hummingbot/hummingbot/pull/3046) Fix Freezing Hummingbot client
+- !3002 Fix invalid orders that are being tracked by the bot
+- !3005 Fix market validators for `amm_arb strategy`
+- !3014 Fix Kraken available balance after running the status command
+- !3046 Fix Freezing Hummingbot client

--- a/docs/release-notes/0.37.1.md
+++ b/docs/release-notes/0.37.1.md
@@ -11,4 +11,4 @@ _Released on March 10, 2021_
 
 This release is a hotfix to version [0.37.0](/release-notes/0.37.0/).
 
-It contains [#3059](https://github.com/hummingbot/hummingbot/pull/3059) a hotfix that resolves trading pair completion not working / not accepting any value when creating a new strategy as described in GitHub issue #3055.
+It contains !3059 a hotfix that resolves trading pair completion not working / not accepting any value when creating a new strategy as described in GitHub issue #3055.

--- a/docs/release-notes/0.37.1.md
+++ b/docs/release-notes/0.37.1.md
@@ -11,4 +11,4 @@ _Released on March 10, 2021_
 
 This release is a hotfix to version [0.37.0](/release-notes/0.37.0/).
 
-It contains [#3059](https://github.com/hummingbot/hummingbot/pull/3059) a hotfix that resolves trading pair completion not working / not accepting any value when creating a new strategy as described in GitHub issue [#3055](https://github.com/hummingbot/hummingbot/issues/3055).
+It contains [#3059](https://github.com/hummingbot/hummingbot/pull/3059) a hotfix that resolves trading pair completion not working / not accepting any value when creating a new strategy as described in GitHub issue #3055.

--- a/docs/release-notes/0.38.0.md
+++ b/docs/release-notes/0.38.0.md
@@ -71,8 +71,8 @@ Learn more about it [here](/operation/config-files/#autofill-import).
 
 ## Bug Fixes
 
-- [#3011](https://github.com/hummingbot/hummingbot/pull/3011) When using `inventory_cost`, the bot will prompt for the `inventory_price` as well
-- [#3135](https://github.com/hummingbot/hummingbot/pull/3135) Fix Binance `perpetual_market_making` funding payment function
-- [#3151](https://github.com/hummingbot/hummingbot/pull/3151) Fix reverse `perpetual_market_making` long and short profit spreads and logs
-- [#3056](https://github.com/hummingbot/hummingbot/pull/3056) Fix sort exchanges alphabetically in the create autocomplete
-- [#3073](https://github.com/hummingbot/hummingbot/pull/3073) Fix Beaxy float rounding
+- !3011 When using `inventory_cost`, the bot will prompt for the `inventory_price` as well
+- !3135 Fix Binance `perpetual_market_making` funding payment function
+- !3151 Fix reverse `perpetual_market_making` long and short profit spreads and logs
+- !3056 Fix sort exchanges alphabetically in the create autocomplete
+- !3073 Fix Beaxy float rounding

--- a/docs/release-notes/0.38.1.md
+++ b/docs/release-notes/0.38.1.md
@@ -15,4 +15,4 @@ In KuCoin's recent announcement, they are upgrading their API keys to v2.0. To s
 
 Related article: https://www.kucoin.com/news/en-kucoin-upgraded-the-api-key-to-version-2
 
-This version also contains [#3213](https://github.com/hummingbot/hummingbot/pull/3213) a hotfix for Huobi connector failing to track orders due to invalid API signatures as described in GitHub issue [#3197](https://github.com/hummingbot/hummingbot/issues/3197).
+This version also contains [#3213](https://github.com/hummingbot/hummingbot/pull/3213) a hotfix for Huobi connector failing to track orders due to invalid API signatures as described in GitHub issue #3197.

--- a/docs/release-notes/0.38.1.md
+++ b/docs/release-notes/0.38.1.md
@@ -11,8 +11,8 @@ _Released on April 15, 2021_
 
 This release is a hotfix to version [0.38.0](/release-notes/0.38.0/).
 
-In KuCoin's recent announcement, they are upgrading their API keys to v2.0. To support this change, we upgraded our connector in [#3211](https://github.com/hummingbot/hummingbot/pull/3211). Hummingbot users can follow [KuCoin API key upgrade operation guide](https://support.kucoin.plus/hc/en-us/articles/900006465403-KuCoin-API-key-upgrade-operation-guide) on how to upgrade API keys.
+In KuCoin's recent announcement, they are upgrading their API keys to v2.0. To support this change, we upgraded our connector in !3211. Hummingbot users can follow [KuCoin API key upgrade operation guide](https://support.kucoin.plus/hc/en-us/articles/900006465403-KuCoin-API-key-upgrade-operation-guide) on how to upgrade API keys.
 
 Related article: https://www.kucoin.com/news/en-kucoin-upgraded-the-api-key-to-version-2
 
-This version also contains [#3213](https://github.com/hummingbot/hummingbot/pull/3213) a hotfix for Huobi connector failing to track orders due to invalid API signatures as described in GitHub issue #3197.
+This version also contains !3213 a hotfix for Huobi connector failing to track orders due to invalid API signatures as described in GitHub issue #3197.

--- a/docs/release-notes/0.39.0.md
+++ b/docs/release-notes/0.39.0.md
@@ -39,10 +39,10 @@ Read more in Avellaneda strategy documentation: [Volatility Sensibility](/strate
 
 ## Bug Fixes
 
-- [#3328](https://github.com/hummingbot/hummingbot/issues/3328) Fixed inconsistent balance updates in AscendEx, resulting to orders not created on specific cycles
+- #3328 Fixed inconsistent balance updates in AscendEx, resulting to orders not created on specific cycles
 - [#3235](https://github.com/hummingbot/hummingbot/pull/3235) Fixed Avellaneda eta calculation, now at the maximum distance from inventory_target and opposing order decays 90% from the original amount
 - [#3218](https://github.com/hummingbot/hummingbot/pull/3218) Fixed Avellaneda spread update during volatility
 - [#3195](https://github.com/hummingbot/hummingbot/pull/3195) Changed condition to check for "volatility is not NaN" when using Avellaneda market making, since when volatility=0 although being valid number "bool(volatility) =False" and the status message was not showing
-- [#3183](https://github.com/hummingbot/hummingbot/issues/3183) Fixed instances when, while running the avellaneda_mm strategy, you enter the `status` command and the output doesn't show the strategy parameters (risk factor, order_book_depth_factor, volatility, and closing time)
+- #3183 Fixed instances when, while running the avellaneda_mm strategy, you enter the `status` command and the output doesn't show the strategy parameters (risk factor, order_book_depth_factor, volatility, and closing time)
 - [#3144](https://github.com/hummingbot/hummingbot/pull/3144) `get_active_markets` in the Kucoin connector was changed to `fetch_active_markets` because the former had a check that prevented the reading of newly added markets
-- [#2790](https://github.com/hummingbot/hummingbot/issues/2790) Parsing errors on Binance US when selecting a trading pair with 4-letter quote asset
+- #2790 Parsing errors on Binance US when selecting a trading pair with 4-letter quote asset

--- a/docs/release-notes/0.39.0.md
+++ b/docs/release-notes/0.39.0.md
@@ -40,9 +40,9 @@ Read more in Avellaneda strategy documentation: [Volatility Sensibility](/strate
 ## Bug Fixes
 
 - #3328 Fixed inconsistent balance updates in AscendEx, resulting to orders not created on specific cycles
-- [#3235](https://github.com/hummingbot/hummingbot/pull/3235) Fixed Avellaneda eta calculation, now at the maximum distance from inventory_target and opposing order decays 90% from the original amount
-- [#3218](https://github.com/hummingbot/hummingbot/pull/3218) Fixed Avellaneda spread update during volatility
-- [#3195](https://github.com/hummingbot/hummingbot/pull/3195) Changed condition to check for "volatility is not NaN" when using Avellaneda market making, since when volatility=0 although being valid number "bool(volatility) =False" and the status message was not showing
+- !3235 Fixed Avellaneda eta calculation, now at the maximum distance from inventory_target and opposing order decays 90% from the original amount
+- !3218 Fixed Avellaneda spread update during volatility
+- !3195 Changed condition to check for "volatility is not NaN" when using Avellaneda market making, since when volatility=0 although being valid number "bool(volatility) =False" and the status message was not showing
 - #3183 Fixed instances when, while running the avellaneda_mm strategy, you enter the `status` command and the output doesn't show the strategy parameters (risk factor, order_book_depth_factor, volatility, and closing time)
-- [#3144](https://github.com/hummingbot/hummingbot/pull/3144) `get_active_markets` in the Kucoin connector was changed to `fetch_active_markets` because the former had a check that prevented the reading of newly added markets
+- !3144 `get_active_markets` in the Kucoin connector was changed to `fetch_active_markets` because the former had a check that prevented the reading of newly added markets
 - #2790 Parsing errors on Binance US when selecting a trading pair with 4-letter quote asset

--- a/docs/release-notes/0.39.1.md
+++ b/docs/release-notes/0.39.1.md
@@ -5,4 +5,4 @@ This release is a hotfix to version [0.39.0](/release-notes/0.39.0).
 
 KuCoin has changed its API endpoint today, which requires users to sign the requests. This results in 404 error issues when restarting the strategy (stop and start) while using the connector.
 
-This version contains a fix [#3506](https://github.com/hummingbot/hummingbot/pull/3506) to an issue when fetching the order book snapshot as described in #3505.
+This version contains a fix !3506 to an issue when fetching the order book snapshot as described in #3505.

--- a/docs/release-notes/0.39.1.md
+++ b/docs/release-notes/0.39.1.md
@@ -5,4 +5,4 @@ This release is a hotfix to version [0.39.0](/release-notes/0.39.0).
 
 KuCoin has changed its API endpoint today, which requires users to sign the requests. This results in 404 error issues when restarting the strategy (stop and start) while using the connector.
 
-This version contains a fix [#3506](https://github.com/hummingbot/hummingbot/pull/3506) to an issue when fetching the order book snapshot as described in [#3505](https://github.com/hummingbot/hummingbot/issues/3505).
+This version contains a fix [#3506](https://github.com/hummingbot/hummingbot/pull/3506) to an issue when fetching the order book snapshot as described in #3505.

--- a/docs/release-notes/0.40.0.md
+++ b/docs/release-notes/0.40.0.md
@@ -57,7 +57,7 @@ If you prefer manual control of orders rather than bot calculated `order_amount`
 
 ## Bug Fixes
 
-- [#3080](https://github.com/hummingbot/hummingbot/pull/3080) `Status --live` sends unwanted script status messages via Telegram
+- !3080 `Status --live` sends unwanted script status messages via Telegram
 - [#3386](https://github.com/hummingbot/hummingbot/pull/3386/commits) Ascendex not handling partial fills
 - [#3342](https://github.com/hummingbot/hummingbot/pull/3342/commits) `cancell_all()` removes manually placed orders in these connectors: Kucoin, Ascendex, BitFinex, Crypto.com
 - [#3409](https://github.com/hummingbot/hummingbot/pull/3409/commits) Avellaneda MM `order_override` on expert mode returns unexpected error running clock tick after calculating volatility

--- a/docs/release-notes/0.40.0.md
+++ b/docs/release-notes/0.40.0.md
@@ -39,7 +39,7 @@ If you prefer manual control of orders rather than bot calculated `order_amount`
 
 ## Other Enhancements
 
-- [#3017](https://github.com/hummingbot/hummingbot/issues/3017) Catch and report exceptions when importing scripts in PMM strategy in the event of syntax or module import errors
+- #3017 Catch and report exceptions when importing scripts in PMM strategy in the event of syntax or module import errors
 
 - Hummingbot client unit tests for the following:
   - Performance Calculation

--- a/docs/release-notes/0.41.0.md
+++ b/docs/release-notes/0.41.0.md
@@ -29,7 +29,7 @@ The hanging orders feature that was previously available only in Pure Market Mak
 
 ## New Rate Oracle Sources : KuCoin and AscendEX
 
-There were reported issues where some assets are not showing their equivalent USD value as described in [#3136](https://github.com/hummingbot/hummingbot/issues/3136). This is because previously, Hummingbot can only use Binance and CoinGecko as sources i.e. if the asset is not listed in any of those two, it cannot be converted.
+There were reported issues where some assets are not showing their equivalent USD value as described in #3136. This is because previously, Hummingbot can only use Binance and CoinGecko as sources i.e. if the asset is not listed in any of those two, it cannot be converted.
 
 Starting this release, users can now select KuCoin and AscendEX from the list of options as the source. This will also help liquidity mining participants who are trading on the said exchanges when checking their balances.
 
@@ -46,30 +46,30 @@ In this release, we will continue testing the strategy and get feedback from use
 
 ## Other Enhancements
 
-- [#3097](https://github.com/hummingbot/hummingbot/issues/3097) Timestamps are now included in the notifications when a buy or sell order is filled. **We want to thank our community member [willzs03](https://github.com/willzs03) for the initial contribution! 🙏**
+- #3097 Timestamps are now included in the notifications when a buy or sell order is filled. **We want to thank our community member [willzs03](https://github.com/willzs03) for the initial contribution! 🙏**
 
 ## Developer Updates
 
 - Implemented 66% minimum unit test coverage requirement for all incoming code changes (with the exception of connectors)
 - Unit tests for [core network module](https://github.com/hummingbot/hummingbot/tree/master/hummingbot/core) have been added. **Thanks to our community member **[petioprv](https://github.com/petioptrv)** for creating the unit tests for `pubsub.pyx`! 🙏**
 - Cleaned up and deleted redundant error catches as well as unused exception in the codebase
-- New connector base class [`PerpetualTrading`](https://github.com/hummingbot/hummingbot/blob/master/hummingbot/connector/perpetual_trading.py#L12) based on `hummingbot/connector/derivative_base.py` to define perpetual trading. More details in this story [#3308](https://github.com/hummingbot/hummingbot/issues/3308)
+- New connector base class [`PerpetualTrading`](https://github.com/hummingbot/hummingbot/blob/master/hummingbot/connector/perpetual_trading.py#L12) based on `hummingbot/connector/derivative_base.py` to define perpetual trading. More details in this story #3308
 - Refactored Spot Perpetual Arbitrage and Perpetual Market Making strategies to comply with `PerpetualTrading` interface
 - Updated Binance Perpetual, Perpetual Finance, and DyDx derivative connectors to derive from `ExchangeBase` and `PerpetualTrading` instead of `DerivativeBase` class
-- Added [`HistoricalVolatilityIndicator`](https://github.com/hummingbot/hummingbot/blob/master/hummingbot/strategy/__utils__/trailing_indicators/historical_volatility.py#L5) indicator class that can be used by any strategy. More details in this story [#3629](https://github.com/hummingbot/hummingbot/issues/3629)
+- Added [`HistoricalVolatilityIndicator`](https://github.com/hummingbot/hummingbot/blob/master/hummingbot/strategy/__utils__/trailing_indicators/historical_volatility.py#L5) indicator class that can be used by any strategy. More details in this story #3629
 - Renamed `AverageVolatilityIndicator` class to [`InstantVolatilityIndicator`](https://github.com/hummingbot/hummingbot/blob/master/hummingbot/strategy/__utils__/trailing_indicators/instant_volatility.py#L5) used by Avellaneda Market Making strategy
 - Unit tests added to Avellaneda Market Making strategy
 - Implement a new `APIThrottler` class which handles the rate limits in several exchange. More information in this pull request [#3656](https://github.com/hummingbot/hummingbot/pull/3656)
 
 ## Bug Fixes
 
-- [#2971](https://github.com/hummingbot/hummingbot/issues/2971) Fixed issue with KuCoin balance pulling from both Trading and Main accounts. **We want to thank our community member [zappra](https://github.com/zappra) for contributing! 🙏**
-- [#3226](https://github.com/hummingbot/hummingbot/issues/3226) Fixed funding fee events notification `get_funding_info()` on Binance Perpetual. **Credits again to [zappra](https://github.com/zappra) for this contribution!**
-- [#3510](https://github.com/hummingbot/hummingbot/issues/3510) KuCoin connector is now usable with paper trading mode using Level-2 order book (aggregated) at 100 pieces of data. More info in [KuCoin API docs](https://docs.kucoin.com/#get-part-order-book-aggregated)
-- [#3521](https://github.com/hummingbot/hummingbot/issues/3521) Fixed an issue where some trading pairs in KuCoin are not recognized
-- [#3578](https://github.com/hummingbot/hummingbot/issues/3578) Fixed issue where hanging orders are not recreated when refreshed after `max_order_age` takes into effect
-- [#3596](https://github.com/hummingbot/hummingbot/issues/3596) Inactive markets in Probit connectors are no longer shown when selecting a trading pair during market configuration
-- [#3611](https://github.com/hummingbot/hummingbot/issues/3611) Trading fees in Hummingbot and Kraken exchange should now be displayed correctly
-- [#3660](https://github.com/hummingbot/hummingbot/issues/3660) Applied the same pure market making fix for `max_order_age` feature in Avellaneda market making strategy
+- #2971 Fixed issue with KuCoin balance pulling from both Trading and Main accounts. **We want to thank our community member [zappra](https://github.com/zappra) for contributing! 🙏**
+- #3226 Fixed funding fee events notification `get_funding_info()` on Binance Perpetual. **Credits again to [zappra](https://github.com/zappra) for this contribution!**
+- #3510 KuCoin connector is now usable with paper trading mode using Level-2 order book (aggregated) at 100 pieces of data. More info in [KuCoin API docs](https://docs.kucoin.com/#get-part-order-book-aggregated)
+- #3521 Fixed an issue where some trading pairs in KuCoin are not recognized
+- #3578 Fixed issue where hanging orders are not recreated when refreshed after `max_order_age` takes into effect
+- #3596 Inactive markets in Probit connectors are no longer shown when selecting a trading pair during market configuration
+- #3611 Trading fees in Hummingbot and Kraken exchange should now be displayed correctly
+- #3660 Applied the same pure market making fix for `max_order_age` feature in Avellaneda market making strategy
 - [#3715](https://github.com/hummingbot/hummingbot/issues/3716) Fixed websocket errors with KuCoin connector when using liquidity mining strategy
-- [#3716](https://github.com/hummingbot/hummingbot/issues/3716) Fixed issue with Probit KR failing to start and fetch order book data
+- #3716 Fixed issue with Probit KR failing to start and fetch order book data

--- a/docs/release-notes/0.41.0.md
+++ b/docs/release-notes/0.41.0.md
@@ -59,7 +59,7 @@ In this release, we will continue testing the strategy and get feedback from use
 - Added [`HistoricalVolatilityIndicator`](https://github.com/hummingbot/hummingbot/blob/master/hummingbot/strategy/__utils__/trailing_indicators/historical_volatility.py#L5) indicator class that can be used by any strategy. More details in this story #3629
 - Renamed `AverageVolatilityIndicator` class to [`InstantVolatilityIndicator`](https://github.com/hummingbot/hummingbot/blob/master/hummingbot/strategy/__utils__/trailing_indicators/instant_volatility.py#L5) used by Avellaneda Market Making strategy
 - Unit tests added to Avellaneda Market Making strategy
-- Implement a new `APIThrottler` class which handles the rate limits in several exchange. More information in this pull request [#3656](https://github.com/hummingbot/hummingbot/pull/3656)
+- Implement a new `APIThrottler` class which handles the rate limits in several exchange. More information in this pull request !3656
 
 ## Bug Fixes
 

--- a/docs/release-notes/0.42.0.md
+++ b/docs/release-notes/0.42.0.md
@@ -28,7 +28,7 @@ Read more in our documentation: [Rate Limits Share Pct](/global-configs/rate-lim
 - Removed mock web server usages from the tests in `/test/hummingbot/core/api_throttler/` which will be replaced in the future and causes the workflow checks in Github to fail occasionally
 - Fixed and added unit tests to not consider AscendEX inflight orders as open order when in "Filled" status
 - Added fields `filled_amount` (Decimal), `creation_timestamp` (int), `status` (int) to `LimitOrder` #3622
-- Created a new multi-limit pool throttler class to handle rate limits where a call can increase multiple pools as described in [#3758](https://github.com/hummingbot/hummingbot/pull/3758)
+- Created a new multi-limit pool throttler class to handle rate limits where a call can increase multiple pools as described in !3758
 - In subsequent releases, we will make changes and improve the multi-pool throttler as well as consolidate existing different version of throttler. More details in this story #3766
 
 ## Bug Fixes

--- a/docs/release-notes/0.42.0.md
+++ b/docs/release-notes/0.42.0.md
@@ -27,16 +27,16 @@ Read more in our documentation: [Rate Limits Share Pct](/global-configs/rate-lim
 
 - Removed mock web server usages from the tests in `/test/hummingbot/core/api_throttler/` which will be replaced in the future and causes the workflow checks in Github to fail occasionally
 - Fixed and added unit tests to not consider AscendEX inflight orders as open order when in "Filled" status
-- Added fields `filled_amount` (Decimal), `creation_timestamp` (int), `status` (int) to `LimitOrder` [#3622](https://github.com/hummingbot/hummingbot/issues/3622)
+- Added fields `filled_amount` (Decimal), `creation_timestamp` (int), `status` (int) to `LimitOrder` #3622
 - Created a new multi-limit pool throttler class to handle rate limits where a call can increase multiple pools as described in [#3758](https://github.com/hummingbot/hummingbot/pull/3758)
-- In subsequent releases, we will make changes and improve the multi-pool throttler as well as consolidate existing different version of throttler. More details in this story [#3766](https://github.com/hummingbot/hummingbot/issues/3766)
+- In subsequent releases, we will make changes and improve the multi-pool throttler as well as consolidate existing different version of throttler. More details in this story #3766
 
 ## Bug Fixes
 
-- [#3547](https://github.com/hummingbot/hummingbot/issues/3547) Fixed issues for matched and unmatched trading pairs especially with USD in HitBTC connector. **Thanks to [TheHolyRoger](https://github.com/TheHolyRoger) for this fix! 🙏**
-- [#3450](https://github.com/hummingbot/hummingbot/issues/3450) Fixed error submitting orders on most USD pairs when using dydx perpetual connector. **Thanks to [trkoneill18](https://github.com/trkoneill18) for this fix! 🙏**
-- [#3645](https://github.com/hummingbot/hummingbot/issues/3645) Fixed format-sensitive values for `markets` parameter in Liquidity Mining strategy
-- [#3648](https://github.com/hummingbot/hummingbot/issues/3648) Updated `ASSET_TO_NAME_MAPPING` in `kucoin_utils.py` to fix the error when selecting BSV markets
-- [#3754](https://github.com/hummingbot/hummingbot/issues/3754) Fixed rate limit issues when using AscendEx connector by implementing the new multi-limit pool throttler class
-- [#3767](https://github.com/hummingbot/hummingbot/issues/3767) Fixed a bug with AscendEx where cancelled orders are showing as active orders using Liquidity Mining strategy
-- [#3777](https://github.com/hummingbot/hummingbot/issues/3777) Fixed orders getting stuck on 'cancelling' message when using multiple orders in AscendEx connector
+- #3547 Fixed issues for matched and unmatched trading pairs especially with USD in HitBTC connector. **Thanks to [TheHolyRoger](https://github.com/TheHolyRoger) for this fix! 🙏**
+- #3450 Fixed error submitting orders on most USD pairs when using dydx perpetual connector. **Thanks to [trkoneill18](https://github.com/trkoneill18) for this fix! 🙏**
+- #3645 Fixed format-sensitive values for `markets` parameter in Liquidity Mining strategy
+- #3648 Updated `ASSET_TO_NAME_MAPPING` in `kucoin_utils.py` to fix the error when selecting BSV markets
+- #3754 Fixed rate limit issues when using AscendEx connector by implementing the new multi-limit pool throttler class
+- #3767 Fixed a bug with AscendEx where cancelled orders are showing as active orders using Liquidity Mining strategy
+- #3777 Fixed orders getting stuck on 'cancelling' message when using multiple orders in AscendEx connector

--- a/docs/release-notes/0.43.0.md
+++ b/docs/release-notes/0.43.0.md
@@ -18,21 +18,21 @@ Read more in our documentation: [Uniswap-v3 LP](/strategies/uniswap-v3-lp)
 - Unit test coverage requirement for pull requests increased from 66% to 75%
 - Global unit test coverage requirement from 42% to 50%
 - New connectors should include unit tests for all classes/modules. Refer to [NDAX connector](https://github.com/hummingbot/hummingbot/tree/master/test/hummingbot/connector/exchange/ndax) for examples of such unit tests
-- Rework of the `uniswap_v3_lp` trading logic reducing complexity [#3999](https://github.com/hummingbot/hummingbot/issues/3999)
-- Added throttler to NDAX for better rate limit handling [#3865](https://github.com/hummingbot/hummingbot/issues/3865)
+- Rework of the `uniswap_v3_lp` trading logic reducing complexity #3999
+- Added throttler to NDAX for better rate limit handling #3865
 - Refactor Crypto.com connector to use `AsyncThrottler` [#3922](https://github.com/hummingbot/hummingbot/pull/3922)
-- Refactor the AscendEX connector to use `AsyncThrottler` [#3889](https://github.com/hummingbot/hummingbot/issues/3889)
-- Added test script for Uniswap V3 to test all endpoints [#124](https://github.com/CoinAlpha/gateway-api/issues/124)
-- Improved order lifecycle logic in NDAX Connector [#3866](https://github.com/hummingbot/hummingbot/issues/3866)
-- Added a component to assist with mocking network activity for connector unit tests [#3947](https://github.com/hummingbot/hummingbot/issues/3947)
+- Refactor the AscendEX connector to use `AsyncThrottler` #3889
+- Added test script for Uniswap V3 to test all endpoints #124
+- Improved order lifecycle logic in NDAX Connector #3866
+- Added a component to assist with mocking network activity for connector unit tests #3947
 
 
 ## Bug Fixes
 
-- [#3062](https://github.com/hummingbot/hummingbot/issues/3062) Fixed various commands on Telegram. This also allows the `balance` command to be executed from the application. **Thanks to [zappra](https://github.com/zappra) for this fix! 🙏**
-- [#2707](https://github.com/hummingbot/hummingbot/issues/2707) Fixed the issue where the bot will fail to run when specifying a `custom_api` price source in the Pure Market Making config
-- [#3452](https://github.com/hummingbot/hummingbot/issues/3452) Fixed issue on Perpetual Market Making where partial fill leads to creating incorrect profit taking order size
-- [#3604](https://github.com/hummingbot/hummingbot/issues/3604) Fixed Binance pair parsing where SC-USDT is not being parsed correctly for Binance connector
-- [#3710](https://github.com/hummingbot/hummingbot/issues/3710) Fixed a bug on Perpetual Market Making when both orders are filled, the bot opens a position instead of creating a new set of orders
-- [#3763](https://github.com/hummingbot/hummingbot/issues/3763) Fixed a bug on Spot Perpetual Arbitrage where the bot does not look for `min_divergence` after the second arbitrage
-- [#3887](https://github.com/hummingbot/hummingbot/issues/3887) Fixed issue with Pure Market Making when the bot does not filter the proposals with invalid prices after it creates the proposals for creating orders
+- #3062 Fixed various commands on Telegram. This also allows the `balance` command to be executed from the application. **Thanks to [zappra](https://github.com/zappra) for this fix! 🙏**
+- #2707 Fixed the issue where the bot will fail to run when specifying a `custom_api` price source in the Pure Market Making config
+- #3452 Fixed issue on Perpetual Market Making where partial fill leads to creating incorrect profit taking order size
+- #3604 Fixed Binance pair parsing where SC-USDT is not being parsed correctly for Binance connector
+- #3710 Fixed a bug on Perpetual Market Making when both orders are filled, the bot opens a position instead of creating a new set of orders
+- #3763 Fixed a bug on Spot Perpetual Arbitrage where the bot does not look for `min_divergence` after the second arbitrage
+- #3887 Fixed issue with Pure Market Making when the bot does not filter the proposals with invalid prices after it creates the proposals for creating orders

--- a/docs/release-notes/0.43.0.md
+++ b/docs/release-notes/0.43.0.md
@@ -20,7 +20,7 @@ Read more in our documentation: [Uniswap-v3 LP](/strategies/uniswap-v3-lp)
 - New connectors should include unit tests for all classes/modules. Refer to [NDAX connector](https://github.com/hummingbot/hummingbot/tree/master/test/hummingbot/connector/exchange/ndax) for examples of such unit tests
 - Rework of the `uniswap_v3_lp` trading logic reducing complexity #3999
 - Added throttler to NDAX for better rate limit handling #3865
-- Refactor Crypto.com connector to use `AsyncThrottler` [#3922](https://github.com/hummingbot/hummingbot/pull/3922)
+- Refactor Crypto.com connector to use `AsyncThrottler` !3922
 - Refactor the AscendEX connector to use `AsyncThrottler` #3889
 - Added test script for Uniswap V3 to test all endpoints #124
 - Improved order lifecycle logic in NDAX Connector #3866

--- a/docs/release-notes/0.43.1.md
+++ b/docs/release-notes/0.43.1.md
@@ -2,4 +2,4 @@
 
 This release is a hotfix to version [0.43.0](/release-notes/0.43.0).
 
-Fixed dependencies issues resulting to errors when installing Hummingbot from source on different operating systems as described in GitHub issue [#4173](https://github.com/hummingbot/hummingbot/issues/4173).
+Fixed dependencies issues resulting to errors when installing Hummingbot from source on different operating systems as described in GitHub issue #4173.

--- a/docs/release-notes/0.44.0.md
+++ b/docs/release-notes/0.44.0.md
@@ -40,6 +40,6 @@ Derivatives products currently offered on the Bybit platform are inverse perpetu
 
 ## Other Enhancements
 
-- [#2967](https://github.com/hummingbot/hummingbot/pull/2967) Refactor `celocli`, update the ticker strings used when parsing `celocli` output. **Thanks to pgold for this fix! 🙏**
-- [#4090](https://github.com/hummingbot/hummingbot/pull/4090) Added `maxNext` parameter to change `storageId` request in Loopring. **Thanks to [trkoneill18](https://github.com/trkoneill18) for this fix! 🙏**
-- [#4210](https://github.com/hummingbot/hummingbot/pull/4210) Updated Blocktane trading pair parser. **Thanks to [trkoneill18](https://github.com/trkoneill18) for this fix! 🙏**
+- !2967 Refactor `celocli`, update the ticker strings used when parsing `celocli` output. **Thanks to pgold for this fix! 🙏**
+- !4090 Added `maxNext` parameter to change `storageId` request in Loopring. **Thanks to [trkoneill18](https://github.com/trkoneill18) for this fix! 🙏**
+- !4210 Updated Blocktane trading pair parser. **Thanks to [trkoneill18](https://github.com/trkoneill18) for this fix! 🙏**

--- a/docs/release-notes/0.44.0.md
+++ b/docs/release-notes/0.44.0.md
@@ -19,24 +19,24 @@ Derivatives products currently offered on the Bybit platform are inverse perpetu
 
 ## Developer Updates
 
-- TWAP strategy is now able to set configuration specifying the start time and the end time, specifying the start time without specifying the end time, and without start time and without an end time. [#3643](https://github.com/hummingbot/hummingbot/issues/3643)
-- Integrated new `APIThrottler` to Binance, Binance Perpetual, Coinzoom, Gate.io, and KuCoin connectors [#3664](https://github.com/hummingbot/hummingbot/issues/3643), [#3666](https://github.com/hummingbot/hummingbot/issues/3666), [#3893](https://github.com/hummingbot/hummingbot/issues/3893), [#3894](https://github.com/hummingbot/hummingbot/issues/3894), [#3891](https://github.com/hummingbot/hummingbot/issues/3891)
-- Integrated `AsyncThrottler` into Kraken connector [#3892](https://github.com/hummingbot/hummingbot/issues/3892)
-- Solved incorrect use of WebSocket in Bittrex [#3867](https://github.com/hummingbot/hummingbot/issues/3867)
-- Added prefix to client order Id for orders created using NDAX connector [#4165](https://github.com/hummingbot/hummingbot/issues/4165)
-- Merged the new hanging order tracker into Pure Market Making. Pure Market Making and Avellaneda's hanging order behavior are now the same. [#3978](https://github.com/hummingbot/hummingbot/issues/3978)
-- Added Uniswap from Gateway-v2 into Hummingbot client [#3984](https://github.com/hummingbot/hummingbot/issues/3984)
-- Removed `asset_mid_price` from Pure Market Making [#4202](https://github.com/hummingbot/hummingbot/issues/4202)
+- TWAP strategy is now able to set configuration specifying the start time and the end time, specifying the start time without specifying the end time, and without start time and without an end time. #3643
+- Integrated new `APIThrottler` to Binance, Binance Perpetual, Coinzoom, Gate.io, and KuCoin connectors [#3664](https://github.com/hummingbot/hummingbot/issues/3643), #3666, #3893, #3894, #3891
+- Integrated `AsyncThrottler` into Kraken connector #3892
+- Solved incorrect use of WebSocket in Bittrex #3867
+- Added prefix to client order Id for orders created using NDAX connector #4165
+- Merged the new hanging order tracker into Pure Market Making. Pure Market Making and Avellaneda's hanging order behavior are now the same. #3978
+- Added Uniswap from Gateway-v2 into Hummingbot client #3984
+- Removed `asset_mid_price` from Pure Market Making #4202
 
 ## Bug Fixes
 
-- [#4089](https://github.com/hummingbot/hummingbot/issues/4089) Fixed dYdX perpetual issue when the bot attempts to place an order it will throw an error. **Thanks to [trkoneill18](https://github.com/trkoneill18) for this fix! 🙏**
-- [#2480](https://github.com/hummingbot/hummingbot/issues/2480) Fixed the issue on Bittrex where the bot assumes that filled orders are unfilled orders, results to errors.
-- [#4100](https://github.com/hummingbot/hummingbot/issues/4100) Fixed a bug where the bot fails to cancel the order and prints `is_testing_mode()` continuously
-- [#4118](https://github.com/hummingbot/hummingbot/issues/4118) Fixed the NDAX fee calculations bug
-- [#4207](https://github.com/hummingbot/hummingbot/issues/4207) Fixed a bug where gateway script still uses old balancer settings
-- [#4297](https://github.com/hummingbot/hummingbot/issues/4297) Fixed the bug on the Binance connector where `split_trading_pair` was not properly imported
-- [#3961](https://github.com/hummingbot/hummingbot/issues/3961) Fixed the issue on Binance Perpetual where setting the same position on the bot and the exchange still throws an error
+- #4089 Fixed dYdX perpetual issue when the bot attempts to place an order it will throw an error. **Thanks to [trkoneill18](https://github.com/trkoneill18) for this fix! 🙏**
+- #2480 Fixed the issue on Bittrex where the bot assumes that filled orders are unfilled orders, results to errors.
+- #4100 Fixed a bug where the bot fails to cancel the order and prints `is_testing_mode()` continuously
+- #4118 Fixed the NDAX fee calculations bug
+- #4207 Fixed a bug where gateway script still uses old balancer settings
+- #4297 Fixed the bug on the Binance connector where `split_trading_pair` was not properly imported
+- #3961 Fixed the issue on Binance Perpetual where setting the same position on the bot and the exchange still throws an error
 
 ## Other Enhancements
 

--- a/docs/release-notes/0.45.0.md
+++ b/docs/release-notes/0.45.0.md
@@ -62,7 +62,7 @@ More information in [Hedge](/strategies/hedge) documentation.
 - #4115 Configured `bitmart` connector to estimate balances to address issues with orders not created consistently in every cycle
 - #4220 Fixed failing to submit orders when `order_amount` is greater than the available balance in Pure Market Making strategy
 - [#4231](https://github.com/hummingbot/hummingbot/issues/4390) Added better error handing in `ndax` connector to fix errors when cancelling or updating orders
-- [#4374](https://github.com/hummingbot/hummingbot/pull/4374) Fixed some Binance test cases that needed to `asyncio.sleep` to complete
+- !4374 Fixed some Binance test cases that needed to `asyncio.sleep` to complete
 - #4390 Fixed `ascend_ex` connector not replying correctly to all PING messages
 - #4425 Fixed `status` output error with liquidity mining strategy when campaign details are not provided from backend
 

--- a/docs/release-notes/0.45.0.md
+++ b/docs/release-notes/0.45.0.md
@@ -39,10 +39,10 @@ More information in [Hedge](/strategies/hedge) documentation.
 - Cleaned up unnecessary dependencies from the `conda` config files for Windows and Mac
 - Removed legacy feature used to enforce a minimum order size in the Hummingbot client when creating or reconfiguring a strategy (`min_quote_order_amount`, `minimum_order_amount`, `default_min_quote`)
 - Removed outdated connectors (`bamboo_relay`, `radar_relay`, `dolomite`, `eterbase`) and any reference to their code
-- Cleaned up unused and legacy codes found in the codebase. More information in [#4420](https://github.com/hummingbot/hummingbot/issues/4420)
+- Cleaned up unused and legacy codes found in the codebase. More information in #4420
 - Replaced `websockets` library with `aiohttp` in `MockWebSocketServer` component and the following connectors: `binance`, `binance_perpetual`, `kucoin`, `ascend_ex`, `gate_io`, `crypto_com`, `ndax`
-- Updated all calls to `asyncio.ensure_future()` to `safe_ensure_future()` to ensure proper error logs from background tasks. More information in [#2516](https://github.com/hummingbot/hummingbot/issues/2516)
-- Removed all Hummingsim dependencies no longer needed. Replaced certain Hummingsim classes with Hummingbot classes. More information in [#4260](https://github.com/hummingbot/hummingbot/issues/4260)
+- Updated all calls to `asyncio.ensure_future()` to `safe_ensure_future()` to ensure proper error logs from background tasks. More information in #2516
+- Removed all Hummingsim dependencies no longer needed. Replaced certain Hummingsim classes with Hummingbot classes. More information in #4260
 - Unit tests added for `bitmart` connector
 - Unit tests added for [`ConfigVar`](https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/config/config_var.py) class
 - Deprecated `MockEventListener` class and replaced with `EventLogger` wherever used
@@ -52,19 +52,19 @@ More information in [Hedge](/strategies/hedge) documentation.
 
 ## Bug Fixes
 
-- [#2274](https://github.com/hummingbot/hummingbot/issues/2274) Corrected trading rule in `min_base_amount_increment` to fix a bug where an `order_amount` with decimal values is adjusted unexpectedly on `coinbase_pro` and `liquid`
-- [#2900](https://github.com/hummingbot/hummingbot/issues/2900) Fixed a bug where cancelling the strategy config creation assigns a `None` value to all of its parameters
-- [#3317](https://github.com/hummingbot/hummingbot/issues/3317) Fixed duplicate logs when orders are filled using `kucoin` connector
-- [#3324](https://github.com/hummingbot/hummingbot/issues/3324) Fixed a bug where positions are not retrieved after restarting Hummingbot when using `dydx_perpetual` connector
-- [#3688](https://github.com/hummingbot/hummingbot/issues/3688) Fixed timeout error when fetching for funding fee with `dydx_perpetual` connector
-- [#3787](https://github.com/hummingbot/hummingbot/issues/3787) Fixed orderbook desynchronization issues with `kucoin` connector
-- [#3967](https://github.com/hummingbot/hummingbot/issues/3967) Fixed `Return %` in UI navbar not in sync with `history` command output
-- [#4115](https://github.com/hummingbot/hummingbot/issues/4115) Configured `bitmart` connector to estimate balances to address issues with orders not created consistently in every cycle
-- [#4220](https://github.com/hummingbot/hummingbot/issues/4220) Fixed failing to submit orders when `order_amount` is greater than the available balance in Pure Market Making strategy
+- #2274 Corrected trading rule in `min_base_amount_increment` to fix a bug where an `order_amount` with decimal values is adjusted unexpectedly on `coinbase_pro` and `liquid`
+- #2900 Fixed a bug where cancelling the strategy config creation assigns a `None` value to all of its parameters
+- #3317 Fixed duplicate logs when orders are filled using `kucoin` connector
+- #3324 Fixed a bug where positions are not retrieved after restarting Hummingbot when using `dydx_perpetual` connector
+- #3688 Fixed timeout error when fetching for funding fee with `dydx_perpetual` connector
+- #3787 Fixed orderbook desynchronization issues with `kucoin` connector
+- #3967 Fixed `Return %` in UI navbar not in sync with `history` command output
+- #4115 Configured `bitmart` connector to estimate balances to address issues with orders not created consistently in every cycle
+- #4220 Fixed failing to submit orders when `order_amount` is greater than the available balance in Pure Market Making strategy
 - [#4231](https://github.com/hummingbot/hummingbot/issues/4390) Added better error handing in `ndax` connector to fix errors when cancelling or updating orders
 - [#4374](https://github.com/hummingbot/hummingbot/pull/4374) Fixed some Binance test cases that needed to `asyncio.sleep` to complete
-- [#4390](https://github.com/hummingbot/hummingbot/issues/4390) Fixed `ascend_ex` connector not replying correctly to all PING messages
-- [#4425](https://github.com/hummingbot/hummingbot/issues/4425) Fixed `status` output error with liquidity mining strategy when campaign details are not provided from backend
+- #4390 Fixed `ascend_ex` connector not replying correctly to all PING messages
+- #4425 Fixed `status` output error with liquidity mining strategy when campaign details are not provided from backend
 
 
 ## Other Enhancements

--- a/docs/release-notes/0.46.0.md
+++ b/docs/release-notes/0.46.0.md
@@ -36,7 +36,7 @@ We are making improvements to the initial implementation of the Avellenada-Stoik
 
 Some advanced parameters were added and we removed those that were not a requirement for the strategy to behave correctly. The updated list of parameters can be found in [Avellaneda Market Making](/strategies/avellaneda-market-making/#strategy-configs) documentation.
 
-In the next release, we will rework the time factor to allow an infinite time horizon as described in Github issue [#4650](https://github.com/hummingbot/hummingbot/issues/4650).
+In the next release, we will rework the time factor to allow an infinite time horizon as described in Github issue #4650.
 
 
 ## Simplified Perpetual Market Making
@@ -50,7 +50,7 @@ Some other changes and improvements are:
 - Added a stop loss order retry logic
 - Unit tests were added to cover the entire strategy
 
-More detailed information on these changes can be found in Github issue [#4565](https://github.com/hummingbot/hummingbot/issues/4565) and updated [Perpetual Market Making](/strategies/perpetual-market-making) documentation.
+More detailed information on these changes can be found in Github issue #4565 and updated [Perpetual Market Making](/strategies/perpetual-market-making) documentation.
 
 
 ## New Spot Connector: MEXC Global
@@ -69,8 +69,8 @@ More information about the connector in [WazirX](/exchanges/wazirx/) documentati
 
 ## Client UI Improvements
 
-- [#4519](https://github.com/hummingbot/hummingbot/issues/4519) Added text margins in the main layout
-- [#4273](https://github.com/hummingbot/hummingbot/issues/4273) Added a graphical appearance to command parameters
+- #4519 Added text margins in the main layout
+- #4273 Added a graphical appearance to command parameters
 - Inspired by [zappra](https://github.com/zappra)'s pull request submission [#3154](https://github.com/hummingbot/hummingbot/pull/3154), running `order_book --live` command will show a live output of the order book in a tab in the logs pane
 
 We will continue to work on adding more features that can be displayed in the tabs. Please feel free to [submit a feature request](https://github.com/hummingbot/hummingbot/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=) for any suggestions.
@@ -79,7 +79,7 @@ We will continue to work on adding more features that can be displayed in the ta
 ## Developer Updates
 
 - Deprecated `dydx` spot connector
-- Introduced a new functionality to allow more accurate sizing of the collateral required for perpetual orders. More information in [#4573](https://github.com/hummingbot/hummingbot/issues/4573)
+- Introduced a new functionality to allow more accurate sizing of the collateral required for perpetual orders. More information in #4573
 - Replace the use of `aioconsole` to start the debug console for the client with the use of `ptpython` from the [prompt-toolkit](https://github.com/prompt-toolkit/ptpython) project due to GPL license incompatibility
 - Allow `get_active_campaigns` function that retrieves liquidity mining campaign information from the miner API to parse tokens from `binance`, `kucoin`, `ascend_ex`. This should display the same status messages for current active campaigns with Miner when using Liquidity Mining strategy
 - Replace `websockets` library with `aiohttp` in `probit` connector
@@ -91,10 +91,10 @@ We will continue to work on adding more features that can be displayed in the ta
 
 ## Bug Fixes
 
-- [#3697](https://github.com/hummingbot/hummingbot/issues/3697) Fixed issue with TWAP strategy where the `order_step_size` accepts a value larger than `target_asset_amount`
-- [#3970](https://github.com/hummingbot/hummingbot/issues/3970) Fixed `DupNewCoid` error for `ascend_ex`
-- [#4192](https://github.com/hummingbot/hummingbot/issues/4192) Fixed `dydx_perpetual` connector's `_update_account_positions` function
-- [#4514](https://github.com/hummingbot/hummingbot/issues/4514) Fixed `dydx_perpetual` connector's `no funding payment` notification
-- [#4559](https://github.com/hummingbot/hummingbot/issues/4559) Fixed issue with TWAP strategy accepting invalid inputs
-- [#4647](https://github.com/hummingbot/hummingbot/issues/4647) Fixed the issue for `gate_io` connector where the bot keeps trying to find the order and prevents the creation of new orders resulting in the `Order not found in inflight orders` error
+- #3697 Fixed issue with TWAP strategy where the `order_step_size` accepts a value larger than `target_asset_amount`
+- #3970 Fixed `DupNewCoid` error for `ascend_ex`
+- #4192 Fixed `dydx_perpetual` connector's `_update_account_positions` function
+- #4514 Fixed `dydx_perpetual` connector's `no funding payment` notification
+- #4559 Fixed issue with TWAP strategy accepting invalid inputs
+- #4647 Fixed the issue for `gate_io` connector where the bot keeps trying to find the order and prevents the creation of new orders resulting in the `Order not found in inflight orders` error
 - [#4756](https://github.com/hummingbot/hummingbot/pull/4756) Fixed memory leaks and order book desynchronization

--- a/docs/release-notes/0.46.0.md
+++ b/docs/release-notes/0.46.0.md
@@ -71,7 +71,7 @@ More information about the connector in [WazirX](/exchanges/wazirx/) documentati
 
 - #4519 Added text margins in the main layout
 - #4273 Added a graphical appearance to command parameters
-- Inspired by [zappra](https://github.com/zappra)'s pull request submission [#3154](https://github.com/hummingbot/hummingbot/pull/3154), running `order_book --live` command will show a live output of the order book in a tab in the logs pane
+- Inspired by [zappra](https://github.com/zappra)'s pull request submission !3154, running `order_book --live` command will show a live output of the order book in a tab in the logs pane
 
 We will continue to work on adding more features that can be displayed in the tabs. Please feel free to [submit a feature request](https://github.com/hummingbot/hummingbot/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=) for any suggestions.
 
@@ -86,7 +86,7 @@ We will continue to work on adding more features that can be displayed in the ta
 - Extracted API-call functionality into a helper class to handle both REST and WS API calls, currently added to `gate_io` connector
 - Removed `NetworkStatus` class in `network_base`, keeping the definition of the class only in `network_iterator` core component. **Thanks to [blakephillips](https://github.com/blakephillips) for this contribution! 🙏**
 - Packages are automatically detected instead of manually listing out the sub-packages in [`setup.py`](https://github.com/hummingbot/hummingbot/blob/master/setup.py#L37)
-- `GateIoAPIOrderBookDataSource` now uses a single websocket connection to open as little websocket connection as possible. More information in [#4562](https://github.com/hummingbot/hummingbot/pull/4562)
+- `GateIoAPIOrderBookDataSource` now uses a single websocket connection to open as little websocket connection as possible. More information in !4562
 
 
 ## Bug Fixes
@@ -97,4 +97,4 @@ We will continue to work on adding more features that can be displayed in the ta
 - #4514 Fixed `dydx_perpetual` connector's `no funding payment` notification
 - #4559 Fixed issue with TWAP strategy accepting invalid inputs
 - #4647 Fixed the issue for `gate_io` connector where the bot keeps trying to find the order and prevents the creation of new orders resulting in the `Order not found in inflight orders` error
-- [#4756](https://github.com/hummingbot/hummingbot/pull/4756) Fixed memory leaks and order book desynchronization
+- !4756 Fixed memory leaks and order book desynchronization

--- a/docs/release-notes/0.8.0.md
+++ b/docs/release-notes/0.8.0.md
@@ -37,9 +37,9 @@ Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone 
 
 Below are the main ones that we fixed in this release:
 
-* Coinbase Pro connector now accounts for already-cancelled orders ([#328](https://github.com/hummingbot/hummingbot/issues/328))
-* Fixed a bug that caused small orders to fail ([#329](https://github.com/hummingbot/hummingbot/issues/329))
-* Fixed a bug that caused stop loss tracker errors for tokens without a price feed ([#336](https://github.com/hummingbot/hummingbot/issues/336))
-* Fixed a bug that displayed the wrong error message in the pure market making strategy when user balances were too low ([#337](https://github.com/hummingbot/hummingbot/issues/337))
-* Fixed a bug that showed orders as active even after they are filled ([#341](https://github.com/hummingbot/hummingbot/issues/341))
+* Coinbase Pro connector now accounts for already-cancelled orders (#328)
+* Fixed a bug that caused small orders to fail (#329)
+* Fixed a bug that caused stop loss tracker errors for tokens without a price feed (#336)
+* Fixed a bug that displayed the wrong error message in the pure market making strategy when user balances were too low (#337)
+* Fixed a bug that showed orders as active even after they are filled (#341)
 

--- a/docs/release-notes/0.9.0.md
+++ b/docs/release-notes/0.9.0.md
@@ -35,8 +35,8 @@ Thanks to everyone who reported bugs! **Note that we pay bug bounties to anyone 
 Below are the main ones that we fixed in this release:
 
 * `status` command now stops printing duplicate output
-* Fixed a bug which causes exchange rate conversion issues when running the cross-exchange market making strategy between DDEX and IDEX [#386](https://github.com/hummingbot/hummingbot/issues/386)
-* Fixed a bug which prevented running the arbitrage and cross-exchange strategies one one exchange [#401](https://github.com/hummingbot/hummingbot/issues/401)
-* Hummingbot now displays warnings if order amounts are lower than minimum order size [#402](https://github.com/hummingbot/hummingbot/issues/402)
-* Fixed a error that stopped the cross-exchange market making strategy after one trade on Binance [#427](https://github.com/hummingbot/hummingbot/issues/427)
-* Fixed a bug in the pure market making strategy that flooded trade logs with error messages when balances were insufficient [#451](https://github.com/hummingbot/hummingbot/issues/451)
+* Fixed a bug which causes exchange rate conversion issues when running the cross-exchange market making strategy between DDEX and IDEX #386
+* Fixed a bug which prevented running the arbitrage and cross-exchange strategies one one exchange #401
+* Hummingbot now displays warnings if order amounts are lower than minimum order size #402
+* Fixed a error that stopped the cross-exchange market making strategy after one trade on Binance #427
+* Fixed a bug in the pure market making strategy that flooded trade logs with error messages when balances were insufficient #451

--- a/docs/release-notes/1.0.0.md
+++ b/docs/release-notes/1.0.0.md
@@ -45,7 +45,7 @@ Three different use cases are possible in the current implementation:
 - B: The trader wants to run the bot only during a defined time during the day    (daily_trading_time)
 - C: The trader wants to run the bot 24 hours, but until a certain date      (fixed_end_date)
 
-More details are described in the Github issue [#4650](https://github.com/hummingbot/hummingbot/issues/4650).
+More details are described in the Github issue #4650.
 
 
 ## Developer Updates
@@ -57,13 +57,13 @@ More details are described in the Github issue [#4650](https://github.com/hummin
 
 ## Bug Fixes
 
-- [#2084](https://github.com/hummingbot/hummingbot/issues/2084) Fixed incorrect trade fees recorded for some connectors
-- [#4712](https://github.com/hummingbot/hummingbot/issues/4712) Fixed for the bottom nav bar, which freezes and stops updating
-- [#4738](https://github.com/hummingbot/hummingbot/issues/4738) Fixed the `NoOpenForCancel` error which causes untracked fills in Ascendex. **Thanks to [zappra](https://github.com/zappra) for this fix! 🙏**
-- [#4815](https://github.com/hummingbot/hummingbot/issues/4815) Fixed parsing errors on some trading pairs for Beaxy and HitBTC
-- [#4828](https://github.com/hummingbot/hummingbot/issues/4828) No printing in the output pane after `status --live` is terminated
-- [#4869](https://github.com/hummingbot/hummingbot/issues/4869) Fixed Avellaneda Market Making order refresh tolerance not working
-- [#4894](https://github.com/hummingbot/hummingbot/issues/4894) Top bid is assigned top ask in Cross Exchange Market Making
+- #2084 Fixed incorrect trade fees recorded for some connectors
+- #4712 Fixed for the bottom nav bar, which freezes and stops updating
+- #4738 Fixed the `NoOpenForCancel` error which causes untracked fills in Ascendex. **Thanks to [zappra](https://github.com/zappra) for this fix! 🙏**
+- #4815 Fixed parsing errors on some trading pairs for Beaxy and HitBTC
+- #4828 No printing in the output pane after `status --live` is terminated
+- #4869 Fixed Avellaneda Market Making order refresh tolerance not working
+- #4894 Top bid is assigned top ask in Cross Exchange Market Making
 - [$4914](https://github.com/hummingbot/hummingbot/issues/4914) Fixed randomly appearing `RunTimeWarning` on the log pane
 - [#4923](https://github.com/hummingbot/hummingbot/pull/4923) Fixed trade monitor freezing 
 - [#4998](https://github.com/hummingbot/hummingbot/pull/4998) Fixed the argument -h and --help they now print help for the particular command, and these options are also being displayed in dropdown menus

--- a/docs/release-notes/1.0.0.md
+++ b/docs/release-notes/1.0.0.md
@@ -65,5 +65,5 @@ More details are described in the Github issue #4650.
 - #4869 Fixed Avellaneda Market Making order refresh tolerance not working
 - #4894 Top bid is assigned top ask in Cross Exchange Market Making
 - [$4914](https://github.com/hummingbot/hummingbot/issues/4914) Fixed randomly appearing `RunTimeWarning` on the log pane
-- [#4923](https://github.com/hummingbot/hummingbot/pull/4923) Fixed trade monitor freezing 
-- [#4998](https://github.com/hummingbot/hummingbot/pull/4998) Fixed the argument -h and --help they now print help for the particular command, and these options are also being displayed in dropdown menus
+- !4923 Fixed trade monitor freezing 
+- !4998 Fixed the argument -h and --help they now print help for the particular command, and these options are also being displayed in dropdown menus

--- a/docs/release-notes/1.0.1.md
+++ b/docs/release-notes/1.0.1.md
@@ -2,5 +2,5 @@
 
 This release is a hotfix to version [1.0.0](/release-notes/1.0.0).
 
-Fixed an issue where `Trade P&L` in `history` command output still shows 0 value even after trades are executed. More information about this bug in #5069 and the hotfix in [#5099](https://github.com/hummingbot/hummingbot/pull/5099).
+Fixed an issue where `Trade P&L` in `history` command output still shows 0 value even after trades are executed. More information about this bug in #5069 and the hotfix in !5099.
 

--- a/docs/release-notes/1.0.1.md
+++ b/docs/release-notes/1.0.1.md
@@ -2,5 +2,5 @@
 
 This release is a hotfix to version [1.0.0](/release-notes/1.0.0).
 
-Fixed an issue where `Trade P&L` in `history` command output still shows 0 value even after trades are executed. More information about this bug in [#5069](https://github.com/hummingbot/hummingbot/issues/5069) and the hotfix in [#5099](https://github.com/hummingbot/hummingbot/pull/5099).
+Fixed an issue where `Trade P&L` in `history` command output still shows 0 value even after trades are executed. More information about this bug in #5069 and the hotfix in [#5099](https://github.com/hummingbot/hummingbot/pull/5099).
 


### PR DESCRIPTION
### Issue
Closes #285

### Description
This pull request addresses the issue related to the presence of a malicious Discord invite link. The link [https://discord.com/invite/2MN3UWg](https://discord.com/invite/2MN3UWg) has been identified as harmful, and this change aims to replace it with the correct and safe link [https://discord.com/invite/hummingbot](https://discord.com/invite/hummingbot).

### Changes Made
- Replaced the malicious Discord invite link.
- Ensured all affected files are updated.

### Additional Context
This change is critical to maintaining the security and integrity of our project. Please review and provide feedback.