### PR TITLE
Replace '2MN3UWg' with 'hummingbot'

### DIFF
--- a/docs/academy-content/posts/commands-and-configs-part-1/index.md
+++ b/docs/academy-content/posts/commands-and-configs-part-1/index.md
@@ -89,9 +89,9 @@ Exchanges connections are handled by the part of the Hummingbot code that we cal
 
 But Hummingbot is constantly evolving, and our team is continually working on adding more **connectors** to our official release.
 
-As an [open-source project](https://github.com/hummingbot/hummingbot), anyone in our community can contribute to building new **connectors**. Our team is always willing to help any developer who wants to help improve Hummingbot. You can always find us on our [Discord server](https://discord.com/invite/2MN3UWg).
+As an [open-source project](https://github.com/hummingbot/hummingbot), anyone in our community can contribute to building new **connectors**. Our team is always willing to help any developer who wants to help improve Hummingbot. You can always find us on our [Discord server](https://discord.com/invite/hummingbot).
 
-But if you aren’t a developer, you can instead [create a request on our Github repo](https://github.com/hummingbot/hummingbot/issues?q=is%3Aopen+is%3Aissue+label%3Aconnector), asking for your favorite exchange to be added- or look for help from our community developers also on our [Discord server](https://discord.com/invite/2MN3UWg).
+But if you aren’t a developer, you can instead [create a request on our Github repo](https://github.com/hummingbot/hummingbot/issues?q=is%3Aopen+is%3Aissue+label%3Aconnector), asking for your favorite exchange to be added- or look for help from our community developers also on our [Discord server](https://discord.com/invite/hummingbot).
 
 We are also working on giving more power to our community.  We recently completed our [second governance vote](../../../blog/posts/changes-to-hummingbot-maintenance-and-governance/index.md), which allowed our liquidity miners to vote for the next connector to be officially supported and included in the next release.
 
@@ -230,7 +230,7 @@ Using `ticker`, the bot will show an update of what are the current prices on th
 
 That’s all for today, but there is still a lot more to cover. There are still a few more commands left to talk about, and we will go back to them in the next article. Meanwhile, if you haven’t already, feel free to join our ever growing community.
 
-We already have an established (and growing) community full of people using Hummingbot, and you can join us on our [Discord channel](https://discord.com/invite/2MN3UWg) to talk about the bot, strategies, liquidity mining and anything else related to the cryptocurrency world, and receive direct support from our team.
+We already have an established (and growing) community full of people using Hummingbot, and you can join us on our [Discord channel](https://discord.com/invite/hummingbot) to talk about the bot, strategies, liquidity mining and anything else related to the cryptocurrency world, and receive direct support from our team.
 
 To keep up with the news and updates, make sure to follow us on [Twitter](https://twitter.com/hummingbot_io), and our community on [Reddit](https://www.reddit.com/r/Hummingbot/).
 

--- a/docs/academy-content/posts/commands-and-configs-part-2/index.md
+++ b/docs/academy-content/posts/commands-and-configs-part-2/index.md
@@ -166,7 +166,7 @@ If you have an idea for a script but have no coding knowledge, you can always cr
 
 This is only a fraction of what can be done with your Hummingbot. Be ready to learn even more about market making bot customization on the next articles.
 
-And remember that you can be part of our community by joining us on our [Discord channel](https://discord.com/invite/2MN3UWg) to talk about the bot, strategies, liquidity mining and anything else related to the cryptocurrency world, and receive direct support from our team.
+And remember that you can be part of our community by joining us on our [Discord channel](https://discord.com/invite/hummingbot) to talk about the bot, strategies, liquidity mining and anything else related to the cryptocurrency world, and receive direct support from our team.
 
 To keep up with the news and updates make sure to follow us on [Twitter](https://twitter.com/hummingbot_io), and our Community on [Reddit](https://www.reddit.com/r/Hummingbot/).
 

--- a/docs/academy-content/posts/guide-to-the-avellaneda-stoikov-strategy/index.md
+++ b/docs/academy-content/posts/guide-to-the-avellaneda-stoikov-strategy/index.md
@@ -177,4 +177,4 @@ Optimal market-making strategies have been a focus of academic research for deca
 
 ## Join Our Community
 
-Join our [Discord channel](https://discord.com/invite/2MN3UWg) to engage with fellow market makers and arbitrageurs. Follow us on [Twitter](https://twitter.com/hummingbot_io) and [Reddit](https://www.reddit.com/r/Hummingbot/) for updates and news. Don't miss our content on market making, including interviews with professional traders, on our [Youtube Channel](https://www.youtube.com/channel/UCxzzdEnDRbylLMWmaMjywOA?sub_confirmation=1).
+Join our [Discord channel](https://discord.com/invite/hummingbot) to engage with fellow market makers and arbitrageurs. Follow us on [Twitter](https://twitter.com/hummingbot_io) and [Reddit](https://www.reddit.com/r/Hummingbot/) for updates and news. Don't miss our content on market making, including interviews with professional traders, on our [Youtube Channel](https://www.youtube.com/channel/UCxzzdEnDRbylLMWmaMjywOA?sub_confirmation=1).

--- a/docs/academy-content/posts/guide-to-the-spot-perpetual-arbitrage-strategy/index.md
+++ b/docs/academy-content/posts/guide-to-the-spot-perpetual-arbitrage-strategy/index.md
@@ -150,7 +150,7 @@ After configuration, simply enter `start` and monitor the bot for arbitrage oppo
 
 ## Join Our Community
 
-Our community, comprising market makers and arbitrageurs, actively supports each other in maximizing Hummingbot's potential. Join our [Discord channel](https://discord.com/invite/2MN3UWg) for discussions on Hummingbot, strategies, liquidity mining, and more. Our team provides direct support here.
+Our community, comprising market makers and arbitrageurs, actively supports each other in maximizing Hummingbot's potential. Join our [Discord channel](https://discord.com/invite/hummingbot) for discussions on Hummingbot, strategies, liquidity mining, and more. Our team provides direct support here.
 
 Stay informed about updates by following us on [Twitter](https://twitter.com/hummingbot_io) and joining our [Reddit Community](https://www.reddit.com/r/Hummingbot/).
 

--- a/docs/academy-content/posts/how-to-arbitrage-amms-like-uniswap-and-balancer/index.md
+++ b/docs/academy-content/posts/how-to-arbitrage-amms-like-uniswap-and-balancer/index.md
@@ -275,7 +275,7 @@ It is important to notice that the trading concept is still the same, no matter 
 
 # **Join our community!**
 
-You can be part of our community by joining us on our [ Discord channel](https://discord.com/invite/2MN3UWg) to talk about the hummingbot, strategies, liquidity mining, and anything else related to the cryptocurrency world, and receive direct support from our team.
+You can be part of our community by joining us on our [ Discord channel](https://discord.com/invite/hummingbot) to talk about the hummingbot, strategies, liquidity mining, and anything else related to the cryptocurrency world, and receive direct support from our team.
 
 To keep up with the news and updates, make sure to follow us on [ Twitter](https://twitter.com/hummingbot_io) and our Community on [ Reddit](https://www.reddit.com/r/Hummingbot/).
 

--- a/docs/academy-content/posts/order-management-configurations/index.md
+++ b/docs/academy-content/posts/order-management-configurations/index.md
@@ -131,7 +131,7 @@ How and when the orders must be created (or canceled) on the market is the final
 
 ## Join our community
 
-Our community is full of market makers and arbitrageurs who are willing to help each other make the best use of Hummingbot. You can join our [Discord channel](https://discord.com/invite/2MN3UWg) to talk about the hummingbot, strategies, liquidity mining, and anything else related to the cryptocurrency world and receive direct support from our team.
+Our community is full of market makers and arbitrageurs who are willing to help each other make the best use of Hummingbot. You can join our [Discord channel](https://discord.com/invite/hummingbot) to talk about the hummingbot, strategies, liquidity mining, and anything else related to the cryptocurrency world and receive direct support from our team.
 
 To keep up with the news and updates, make sure to follow us on [Twitter](https://twitter.com/hummingbot_io) and our Community on [Reddit](https://www.reddit.com/r/Hummingbot/).
 

--- a/docs/academy-content/posts/what-is-inventory-risk/index.md
+++ b/docs/academy-content/posts/what-is-inventory-risk/index.md
@@ -40,7 +40,7 @@ Here is what we’ll cover in today's article:
 <!-- more -->
 
 
-And as always, you are welcome to join the #trader-chat on our [Discord](https://discord.com/invite/2MN3UWg) to discuss with the community how to improve your market making strategy.
+And as always, you are welcome to join the #trader-chat on our [Discord](https://discord.com/invite/hummingbot) to discuss with the community how to improve your market making strategy.
 
 ### What is Inventory risk?
 

--- a/docs/client/log-files.md
+++ b/docs/client/log-files.md
@@ -25,4 +25,4 @@ the oldest ones will be deleted in order to limit disk storage usage.
 The log rotation feature was added in [Hummingbot version 0.17.0](https://docs.hummingbot.io/release-notes/0.17.0/#log-file-management-data-storage).
 
 If you are looking for support in handling errors or have questions about behavior reported in logs,
-you can find ways of contacting the team or community in our [support section](https://discord.com/invite/2MN3UWg).
+you can find ways of contacting the team or community in our [support section](https://discord.com/invite/hummingbot).


### PR DESCRIPTION
### Issue
Closes #285

### Description
This pull request addresses the issue related to the presence of a malicious Discord invite link. The link [https://discord.com/invite/2MN3UWg](https://discord.com/invite/2MN3UWg) has been identified as harmful, and this change aims to replace it with the correct and safe link [https://discord.com/invite/hummingbot](https://discord.com/invite/hummingbot).

### Changes Made
- Replaced the malicious Discord invite link.
- Ensured all affected files are updated.

### Additional Context
This change is critical to maintaining the security and integrity of our project. Please review and provide feedback.