### PR TITLE
Replace '2MN3UWg' with 'hummingbot'

### DIFF
--- a/docs/blog/posts/2020-10-hummingbot-academy/index.mdx
+++ b/docs/blog/posts/2020-10-hummingbot-academy/index.mdx
@@ -94,7 +94,7 @@ Here is what you can expect from the **Hummingbot Academy** in a near future:
 
 And a lot more!
 
-These are still the early days of the Academy, and there is a long road ahead of us, and we want you to be part of this journey. [Join our discord channel](https://discord.com/invite/2MN3UWg) and let us know what content you want to see on the Hummingbot Academy and also to discuss strategies with our community.
+These are still the early days of the Academy, and there is a long road ahead of us, and we want you to be part of this journey. [Join our discord channel](https://discord.com/invite/hummingbot) and let us know what content you want to see on the Hummingbot Academy and also to discuss strategies with our community.
 
 Meanwhile, here is the all the educational content we have already published for you to revisit:
 

--- a/docs/blog/posts/2020-10-inventory-risk/index.mdx
+++ b/docs/blog/posts/2020-10-inventory-risk/index.mdx
@@ -36,7 +36,7 @@ Here is what we’ll cover in today's article:
 
 - **How to mitigate inventory risk with Hummingbot**
 
-And as always, you are welcome to join the #trader-chat on our [Discord](https://discord.com/invite/2MN3UWg) to discuss with the community how to improve your market making strategy.
+And as always, you are welcome to join the #trader-chat on our [Discord](https://discord.com/invite/hummingbot) to discuss with the community how to improve your market making strategy.
 
 ### What is Inventory risk?
 

--- a/docs/blog/posts/2020-11-commands-and-configs-part1/index.mdx
+++ b/docs/blog/posts/2020-11-commands-and-configs-part1/index.mdx
@@ -96,9 +96,9 @@ Exchanges connections are handled by the part of the Hummingbot code that we cal
 
 But Hummingbot is constantly evolving, and our team is continually working on adding more **connectors** to our official release.
 
-As an [open-source project](https://github.com/CoinAlpha/hummingbot), anyone in our community can contribute to building new **connectors**. Our team is always willing to help any developer who wants to help improve Hummingbot. You can always find us on our [Discord server](https://discord.com/invite/2MN3UWg).
+As an [open-source project](https://github.com/CoinAlpha/hummingbot), anyone in our community can contribute to building new **connectors**. Our team is always willing to help any developer who wants to help improve Hummingbot. You can always find us on our [Discord server](https://discord.com/invite/hummingbot).
 
-But if you aren’t a developer, you can instead [create a request on our Github repo](https://github.com/CoinAlpha/hummingbot/issues?q=is%3Aopen+is%3Aissue+label%3Aconnector), asking for your favorite exchange to be added- or look for help from our community developers also on our [Discord server](https://discord.com/invite/2MN3UWg).
+But if you aren’t a developer, you can instead [create a request on our Github repo](https://github.com/CoinAlpha/hummingbot/issues?q=is%3Aopen+is%3Aissue+label%3Aconnector), asking for your favorite exchange to be added- or look for help from our community developers also on our [Discord server](https://discord.com/invite/hummingbot).
 
 We are also working on giving more power to our community.  We recently completed our [second governance vote](https://hummingbot.io/blog/2020-10-governance-proposal-2/), which allowed our liquidity miners to vote for the next connector to be officially supported and included in the next release.
 
@@ -240,7 +240,7 @@ Using `ticker`, the bot will show an update of what are the current prices on th
 
 That’s all for today, but there is still a lot more to cover. There are still a few more commands left to talk about, and we will go back to them in the next article. Meanwhile, if you haven’t already, feel free to join our ever growing community.
 
-We already have an established (and growing) community full of people using Hummingbot, and you can join us on our [Discord channel](https://discord.com/invite/2MN3UWg) to talk about the bot, strategies, liquidity mining and anything else related to the cryptocurrency world, and receive direct support from our team.
+We already have an established (and growing) community full of people using Hummingbot, and you can join us on our [Discord channel](https://discord.com/invite/hummingbot) to talk about the bot, strategies, liquidity mining and anything else related to the cryptocurrency world, and receive direct support from our team.
 
 To keep up with the news and updates, make sure to follow us on [Twitter](https://twitter.com/hummingbot_io), and our community on [Reddit](https://www.reddit.com/r/Hummingbot/).
 

--- a/docs/blog/posts/2020-11-commands-and-configs-part2/index.mdx
+++ b/docs/blog/posts/2020-11-commands-and-configs-part2/index.mdx
@@ -160,7 +160,7 @@ If you have an idea for a script but have no coding knowledge, you can always cr
 
 This is only a fraction of what can be done with your Hummingbot. Be ready to learn even more about market making bot customization on the next articles.
 
-And remember that you can be part of our community by joining us on our [Discord channel](https://discord.com/invite/2MN3UWg) to talk about the bot, strategies, liquidity mining and anything else related to the cryptocurrency world, and receive direct support from our team.
+And remember that you can be part of our community by joining us on our [Discord channel](https://discord.com/invite/hummingbot) to talk about the bot, strategies, liquidity mining and anything else related to the cryptocurrency world, and receive direct support from our team.
 
 To keep up with the news and updates make sure to follow us on [Twitter](https://twitter.com/hummingbot_io), and our Community on [Reddit](https://www.reddit.com/r/Hummingbot/).
 

--- a/docs/blog/posts/2020-12-amm-arbitrage-uniswap-balancer/index.mdx
+++ b/docs/blog/posts/2020-12-amm-arbitrage-uniswap-balancer/index.mdx
@@ -275,7 +275,7 @@ It is important to notice that the trading concept is still the same, no matter 
 
 # **Join our community!**
 
-You can be part of our community by joining us on our [ Discord channel](https://discord.com/invite/2MN3UWg) to talk about the hummingbot, strategies, liquidity mining, and anything else related to the cryptocurrency world, and receive direct support from our team.
+You can be part of our community by joining us on our [ Discord channel](https://discord.com/invite/hummingbot) to talk about the hummingbot, strategies, liquidity mining, and anything else related to the cryptocurrency world, and receive direct support from our team.
 
 To keep up with the news and updates, make sure to follow us on [ Twitter](https://twitter.com/hummingbot_io) and our Community on [ Reddit](https://www.reddit.com/r/Hummingbot/).
 

--- a/docs/blog/posts/2020-12-wrapped-celo-uniswap-arbitrage/index.mdx
+++ b/docs/blog/posts/2020-12-wrapped-celo-uniswap-arbitrage/index.mdx
@@ -178,7 +178,7 @@ But Hummingbot aims to facilitate this kind of strategy, allowing traders to wor
 
 ## Join our community!
 
-Our community is full of market makers and arbitrageurs who are willing to help each other make the best use of Hummingbot. You can join our [Discord channel](https://discord.com/invite/2MN3UWg) to talk about the hummingbot, strategies, liquidity mining, and anything else related to the cryptocurrency world, and receive direct support from our team.
+Our community is full of market makers and arbitrageurs who are willing to help each other make the best use of Hummingbot. You can join our [Discord channel](https://discord.com/invite/hummingbot) to talk about the hummingbot, strategies, liquidity mining, and anything else related to the cryptocurrency world, and receive direct support from our team.
 
 To keep up with the news and updates, make sure to follow us on [Twitter](https://twitter.com/hummingbot_io) and our Community on [Reddit](https://www.reddit.com/r/Hummingbot/).
 

--- a/docs/blog/posts/2021-02-extracting-value-hbot-market-maker-orders/index.mdx
+++ b/docs/blog/posts/2021-02-extracting-value-hbot-market-maker-orders/index.mdx
@@ -215,7 +215,7 @@ How and when the orders must be created (or canceled) on the market is the final
 
 ## Join our community
 
-Our community is full of market makers and arbitrageurs who are willing to help each other make the best use of Hummingbot. You can join our [Discord channel](https://discord.com/invite/2MN3UWg) to talk about the hummingbot, strategies, liquidity mining, and anything else related to the cryptocurrency world and receive direct support from our team.
+Our community is full of market makers and arbitrageurs who are willing to help each other make the best use of Hummingbot. You can join our [Discord channel](https://discord.com/invite/hummingbot) to talk about the hummingbot, strategies, liquidity mining, and anything else related to the cryptocurrency world and receive direct support from our team.
 
 To keep up with the news and updates, make sure to follow us on [Twitter](https://twitter.com/hummingbot_io) and our Community on [Reddit](https://www.reddit.com/r/Hummingbot/).
 

--- a/docs/blog/posts/2021-03-spot-perpetual-protocol-guide/index.mdx
+++ b/docs/blog/posts/2021-03-spot-perpetual-protocol-guide/index.mdx
@@ -200,7 +200,7 @@ And there you go. All you have to do now is enter `start` and watch the bot look
 
 
 
-Our community is full of market makers and arbitrageurs who are willing to help each other make the best use of Hummingbot. You can join our [Discord channel](https://discord.com/invite/2MN3UWg) to talk about the hummingbot, strategies, liquidity mining, and anything else related to the cryptocurrency world and receive direct support from our team.
+Our community is full of market makers and arbitrageurs who are willing to help each other make the best use of Hummingbot. You can join our [Discord channel](https://discord.com/invite/hummingbot) to talk about the hummingbot, strategies, liquidity mining, and anything else related to the cryptocurrency world and receive direct support from our team.
 
 To keep up with the news and updates, make sure to follow us on [Twitter](https://twitter.com/hummingbot_io) and our Community on [Reddit](https://www.reddit.com/r/Hummingbot/).
 

--- a/docs/blog/posts/2021-04-avellaneda-stoikov-market-making-strategy/index.mdx
+++ b/docs/blog/posts/2021-04-avellaneda-stoikov-market-making-strategy/index.mdx
@@ -267,7 +267,7 @@ If you have an interesting model that could be interesting for our team to look 
 
 ## Join our community
 
-Our community is full of market makers and arbitrageurs who are willing to help each other make the best use of Hummingbot. You can join our [Discord channel](https://discord.com/invite/2MN3UWg) to talk about the hummingbot, strategies, liquidity mining, and anything else related to the cryptocurrency world and receive direct support from our team.
+Our community is full of market makers and arbitrageurs who are willing to help each other make the best use of Hummingbot. You can join our [Discord channel](https://discord.com/invite/hummingbot) to talk about the hummingbot, strategies, liquidity mining, and anything else related to the cryptocurrency world and receive direct support from our team.
 
 To keep up with the news and updates, make sure to follow us on [Twitter](https://twitter.com/hummingbot_io) and our Community on [Reddit](https://www.reddit.com/r/Hummingbot/).
 

--- a/docs/operation/log-files.md
+++ b/docs/operation/log-files.md
@@ -25,4 +25,4 @@ the oldest ones will be deleted in order to limit disk storage usage.
 The log rotation feature was added in [Hummingbot version 0.17.0](https://docs.hummingbot.io/release-notes/0.17.0/#log-file-management-data-storage).
 
 If you are looking for support in handling errors or have questions about behavior reported in logs,
-you can find ways of contacting the team or community in our [support section](https://discord.com/invite/2MN3UWg).
+you can find ways of contacting the team or community in our [support section](https://discord.com/invite/hummingbot).


### PR DESCRIPTION
### Issue
Closes #285

### Description
This pull request addresses the issue related to the presence of a malicious Discord invite link. The link [https://discord.com/invite/2MN3UWg](https://discord.com/invite/2MN3UWg) has been identified as harmful, and this change aims to replace it with the correct and safe link [https://discord.com/invite/hummingbot](https://discord.com/invite/hummingbot).

### Changes Made
- Replaced the malicious Discord invite link.
- Ensured all affected files are updated.

### Additional Context
This change is critical to maintaining the security and integrity of our project. Please review and provide feedback.