### PR TITLE
(feat) Update rate limit and Derive Account Type

### DIFF
--- a/docs/exchanges/derive/index.md
+++ b/docs/exchanges/derive/index.md
@@ -33,6 +33,50 @@
 
 - **Derive Rate Limit:**  <https://docs.derive.xyz/reference/rate-limits>
 
+# Rate Limits
+
+The below rate limits have been implemented to safeguard our system. Rate limiters use a **"fixed window" algorithm** to discretely refill the request allowance every 5 seconds.
+
+**Market makers are eligible for higher rate limits.**  
+To apply for increased rates, please contact our support team.
+
+| Type          | Matching | Per-Instrument Matching | Non-Matching | Connections      | Burst Multiplier |
+|---------------|----------|--------------------------|---------------|------------------|------------------|
+| Trader        | 1 TPS    | 1 TPS                    | 5 TPS         | 4x per IP        | 5x               |
+| Market Maker  | 500+ TPS | 10+ TPS                  | 500+ TPS      | up to 64x per IP | 5x               |
+
+> **Note:**  
+> Burst requests for both REST and WebSockets are refreshed every 5 seconds.  
+> For example, a trader can send 5× matching requests in a single burst but must wait 5 seconds before any further requests can be sent.
+
+
+## Matching, Non-Matching, and Custom Requests
+
+The below requests are counted as **matching** and **per-instrument matching** requests:
+
+- `private/order`
+- `private/replace` *(counted as 1 request)*
+- `private/cancel`
+- `private/cancel_by_nonce`
+- `private/cancel_by_instrument`
+- `private/cancel_by_label` *(if `instrument_name` param is set)*
+
+### Custom Rate-Limited Requests
+
+- `private/cancel_all` – **1 TPS**
+- `private/cancel_by_label` – **10 TPS** *(if `instrument_name` param is **NOT** set)*
+
+All requests outside of the above are counted as **non-matching**.
+
+---
+
+## REST
+
+All **non-matching** requests over the **REST API** are rate limited per IP at a flat **10 TPS** with a **5x burst**.
+
+If the limit is crossed, a **`429 Too Many Requests`** response is returned.
+
+
 ## 🔑 How to Connect
 
 ### Generate API Keys
@@ -81,6 +125,8 @@ Enter Your Derive Wallet address >>>
 Enter your wallet private key >>>
 
 Enter your Subaccount ID >>>
+
+Enter your Derive Account Type (trader/market_maker) >>>
 
 ```
 
@@ -137,6 +183,7 @@ From inside the Hummingbot client, run `connect derive_perpetual`:
 Enter Your DerivePerpetual Wallet address >>>
 Enter your wallet private key >>>
 Enter your Subaccount ID >>>
+Enter your Derive Account Type (trader/market_maker) >>>
 
 ```
 


### PR DESCRIPTION
This pull request updates the documentation for the Derive exchange, introducing detailed rate-limiting guidelines and modifying the connection setup instructions. The most important changes include the addition of rate limit details and new prompts for specifying account types during the connection process.

### Updates to rate-limiting guidelines:
* Added a new section on rate limits, explaining the fixed window algorithm, rate limits for traders and market makers, and burst request behavior. Includes a detailed table of limits for different request types and user categories.
* Clarified the classification of matching, non-matching, and custom requests, with specific rate limits for each.
* Added REST API-specific rate limits, specifying a flat 10 TPS limit for non-matching requests and the behavior when limits are exceeded.

### Modifications to connection setup:
* Updated the connection prompts to include a new field for specifying the Derive account type (`trader` or `market_maker`). [[1]](diffhunk://#diff-de3cc4870cdab65c153d616fe84a59080f75bfc03f012ab7c275bbffc265c7daR129-R130) [[2]](diffhunk://#diff-de3cc4870cdab65c153d616fe84a59080f75bfc03f012ab7c275bbffc265c7daR186)