### PR TITLE
Docs: link XRPL wallet setup to step-by-step blog guide

### DIFF
--- a/docs/blog/posts/using-xrpl-with-hummingbot/index.md
+++ b/docs/blog/posts/using-xrpl-with-hummingbot/index.md
@@ -42,6 +42,8 @@ Visit the official XRPL Testnet Faucet:
 
 Select `Testnet` from the dropdown and click **Generate Testnet Credentials**.
 
+The faucet labels this as a testnet wallet, but the address and secret key are standard XRPL credentials — the same keys also work on **mainnet**. Testnet only funds the account with test XRP; it does not limit where you can use the wallet.
+
 [![Faucet Screenshot](faucet.webp)](faucet.webp)
 
 Copy the **Wallet Address** and **Secret Key** somewhere safe.

--- a/docs/exchanges/xrpl.md
+++ b/docs/exchanges/xrpl.md
@@ -24,7 +24,9 @@
 
 ### Create and fund a XRPL Wallet
 
-* Please follow the steps in this guide to create a XRPL wallet: [Ripple - Create wallet](https://xrpl.org/)
+!!! tip "Step-by-step guide"
+    See [Using XRP Ledger with Hummingbot](../blog/posts/using-xrpl-with-hummingbot/index.md) for a full walkthrough on creating a wallet, connecting it to Hummingbot, and running a strategy.
+
 * Make sure you fund your wallet with enough XRP and tokens for trading
 
 | Chain    | Networks             |


### PR DESCRIPTION
## Summary
- Replace the bare link to xrpl.org in the XRPL exchange docs with a tip pointing to the full step-by-step blog walkthrough for creating/connecting a wallet.
- Clarify in the blog guide that faucet-generated testnet credentials are standard XRPL keys that also work on mainnet — testnet only funds the account, it doesn't restrict wallet usage.

## Test plan
- [ ] Verify the relative link from `docs/exchanges/xrpl.md` to the blog post resolves correctly when the site is built
- [ ] Proofread the new note in the blog post for clarity/accuracy