### PR TITLE
Add Condor feedback survey to docs and related pages

### DIFF
--- a/docs/blog/posts/introducing-condor/index.md
+++ b/docs/blog/posts/introducing-condor/index.md
@@ -15,6 +15,8 @@ We're excited to introduce **[Condor](https://condor.hummingbot.org)**, an open 
 
 <!-- more -->
 
+--8<-- "docs/includes/condor-feedback.md"
+
 ## The Condor Harness
 
 Condor is an open source AI agent harness, similar to [OpenClaw](https://github.com/anthropics/openClaw). Just as OpenClaw helps you create and manage agents that automate personal productivity tasks, Condor helps you create and manage agents that automate trading tasks, as well perform trades using natural language.
@@ -247,6 +249,7 @@ Ready to try Condor? Follow the [Getting Started Guide](https://condor.hummingbo
 
 Condor is in active development. Share feedback and contribute ideas:
 
+- **Survey**: [Take the 2-minute Condor survey](https://forms.gle/7NpG3RtgfLrmpUNY8) — it directly shapes what we build next
 - **Discord**: Join the [#condor-feedback](https://discord.gg/hummingbot) channel for discussion
 - **GitHub**: Create issues in the [Condor repo](https://github.com/hummingbot/condor/issues) for bugs and enhancements
 

--- a/docs/blog/posts/quickstart-dashboard/index.md
+++ b/docs/blog/posts/quickstart-dashboard/index.md
@@ -11,6 +11,8 @@ categories:
 !!! warning "Deprecation Notice"
     Hummingbot Dashboard is deprecated. We recommend using [Condor](../../../installation/condor.md) instead — a Telegram and web-based interface for managing Hummingbot bots. See the [Condor documentation](../../../condor/index.md) for more details.
 
+--8<-- "docs/includes/condor-feedback.md"
+
 In this tutorial, we'll guide you through installing the Hummingbot Dashboard app, which helps you connect exchange credentials, create/backtest a strategy configuration, and deploy a fleet of bots!
 
 Watch this video for an overview and walkthrough of the features in Hummingbot 2.0:

--- a/docs/blog/posts/securing-condor-and-hummingbot-api-with-tailscale/index.md
+++ b/docs/blog/posts/securing-condor-and-hummingbot-api-with-tailscale/index.md
@@ -22,6 +22,8 @@ This guide explains **why exposing the API is risky**, **simple steps you can ta
 
 <!-- more -->
 
+--8<-- "docs/includes/condor-feedback.md"
+
 ## Who is this guide for?
 
 You do **not** need to be a networking expert. This article is written for traders and operators who:
@@ -397,6 +399,7 @@ Tailscale is not a substitute for strong API credentials—but together they giv
 ## Further reading
 
 - [Condor documentation](https://condor.hummingbot.org)
+- [Give Condor feedback](https://forms.gle/7NpG3RtgfLrmpUNY8) — 2-minute survey that shapes the roadmap
 - [Hummingbot API documentation](https://hummingbot.org/hummingbot-api/)
 - [Hummingbot API installation](https://hummingbot.org/hummingbot-api/installation/)
 - [Condor README — Secure Connection via Tailscale](https://github.com/hummingbot/condor)

--- a/docs/condor/index.md
+++ b/docs/condor/index.md
@@ -5,6 +5,8 @@
 !!! note "Full Documentation"
     The complete Condor documentation has moved to a dedicated site. Visit **[condor.hummingbot.org](https://condor.hummingbot.org)** for full installation guides, Trading Agents Standard specification, and API reference.
 
+--8<-- "docs/includes/condor-feedback.md"
+
 <iframe style="width:100%; min-height:400px;" src="https://www.youtube.com/embed/O93R_ddB-8o" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## What is Condor?
@@ -43,5 +45,6 @@ This script clones the repository, installs dependencies, and prompts you for yo
 |----------|------|
 | Full Documentation | [condor.hummingbot.org](https://condor.hummingbot.org) |
 | GitHub Repository | [github.com/hummingbot/condor](https://github.com/hummingbot/condor) |
+| Give Feedback | [2-minute survey](https://forms.gle/7NpG3RtgfLrmpUNY8) |
 | Discord Support | [#condor-feedback](https://discord.gg/hummingbot) |
 | Hummingbot API | [Hummingbot API Docs](../hummingbot-api/index.md) |

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -9,6 +9,8 @@ Choose your path based on your needs:
 - **[Condor Quickstart](../installation/condor.md)** - Recommended for Trading Agents, cloud deployments, multi-bot management, and modern interfaces (Telegram, web dashboard)
 - **[Hummingbot Client Quickstart](../installation/hummingbot-client.md)** - Best for local usage, learning Hummingbot, and running single bot instances with [`hbot`](../client/hbot-cli.md)
 
+--8<-- "docs/includes/condor-feedback.md"
+
 !!! note "For Developers"
     If you're a developer looking to build custom strategies or exchange connectors, see [Source Installation](../client/installation.md) for Hummingbot Client or [Hummingbot API Installation](../hummingbot-api/installation.md) for the API.
 

--- a/docs/includes/condor-feedback.md
+++ b/docs/includes/condor-feedback.md
@@ -1,0 +1,4 @@
+!!! tip "Help shape Condor"
+    What's working? What's confusing? What do you wish Condor could do? The survey takes **2 minutes**, and every response goes to the Hummingbot Foundation team and directly shapes what we build next.
+
+    **[Take the 2-minute survey →](https://forms.gle/7NpG3RtgfLrmpUNY8)**

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,7 +116,7 @@ graph TB
 
     AI harness for building and running agentic strategies and bot instances.
 
-    [:octicons-arrow-right-24: Documentation](condor/index.md) · [:octicons-mark-github-16: GitHub](https://github.com/hummingbot/condor) <span class="repo-stars" data-repo="hummingbot/condor">:octicons-star-16: —</span>
+    [:octicons-arrow-right-24: Documentation](condor/index.md) · [:octicons-mark-github-16: GitHub](https://github.com/hummingbot/condor) · [:octicons-comment-discussion-16: Feedback](https://forms.gle/7NpG3RtgfLrmpUNY8) <span class="repo-stars" data-repo="hummingbot/condor">:octicons-star-16: —</span>
 
 -   :octicons-mark-github-16:{ .lg .middle } __Hummingbot Client__
 

--- a/docs/installation/condor.md
+++ b/docs/installation/condor.md
@@ -6,6 +6,11 @@ For full installation instructions, see the Condor documentation:
 
 [:material-arrow-right: **Condor Documentation**](https://condor.hummingbot.org){ .md-button .md-button--primary }
 
+!!! tip "Help shape Condor"
+    Got Condor running? Tell us how install went, what's confusing, and what you need next. The survey takes **2 minutes** and directly shapes what we build next.
+
+    **[Take the 2-minute survey →](https://forms.gle/7NpG3RtgfLrmpUNY8)**
+
 ## Quick Install
 
 ```bash
@@ -38,6 +43,7 @@ The install script will prompt for:
 ## Learn More
 
 - [Condor Documentation](https://condor.hummingbot.org) - Full guides for Trading Agents, executors, and more
+- [Give Feedback](https://forms.gle/7NpG3RtgfLrmpUNY8) - 2-minute survey that shapes the Condor roadmap
 - [Hummingbot API Reference](../hummingbot-api/index.md) - API endpoints and developer guide
 - [Hummingbot API — Tailscale](../hummingbot-api/tailscale.md) - Recommended for production (private API access)
 - [MCP Installation](../mcp/installation.md) - Connect AI assistants to Hummingbot API

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -60,6 +60,8 @@ The AI harness for building and running agentic strategies and bot instances. Be
 
 For full documentation, see [condor.hummingbot.org](https://condor.hummingbot.org).
 
+--8<-- "docs/includes/condor-feedback.md"
+
 ### Developers
 
 For developers who want to add/customize exchange connectors, extend strategies, or otherwise modify the Hummingbot codebase:


### PR DESCRIPTION
## Summary
- Add a reusable Condor feedback callout linking to the 2-minute survey (https://forms.gle/7NpG3RtgfLrmpUNY8)
- Surface it on the Condor page, Condor Quickstart, installation overview, homepage Condor card, and documentation landing
- Place the callout at the top of Condor-related blog posts (Introducing Condor, Tailscale guide, Dashboard deprecation)

## Test plan
- [ ] Confirm the survey tip appears on `/condor/`, `/installation/`, and `/installation/condor/`
- [ ] Confirm the homepage Condor card includes a Feedback link to the Google Form
- [ ] Open Introducing Condor, Securing Condor with Tailscale, and Dashboard Quickstart and confirm the tip is visible near the top
- [ ] Click through to https://forms.gle/7NpG3RtgfLrmpUNY8 from at least one docs page and one blog post


Made with [Cursor](https://cursor.com)